### PR TITLE
Add bash to ease use with dokku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apk add --update \
     postgresql-dev \
     tzdata \
     curl-dev \
+    bash \
     libc6-compat \
  && rm -rf /var/cache/apk/* 
 


### PR DESCRIPTION
Bash is used by ansible-dokku and dokku to run command in container like bundle