### PR TITLE
Fix /api/v1/topics

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -31,8 +31,14 @@ class Repository < ApplicationRecord
   scope :with_funding, -> { where("metadata->'funding' is not null") }
 
   def self.topics
-    Rails.cache.fetch("host/#{self.id}/topics", expires_in: 1.week) do
-      Repository.connection.select_rows("SELECT topics, COUNT(topics) AS topics_count FROM (SELECT id, unnest(topics) AS topics FROM repositories WHERE topics IS NOT NULL AND array_length(topics, 1) > 0) AS foo GROUP BY topics ORDER BY topics_count DESC, topics ASC LIMIT 50000;")
+    if self == Repository
+      Rails.cache.fetch("topics", expires_in: 1.week) do
+        Repository.connection.select_rows("SELECT topics, COUNT(topics) AS topics_count FROM (SELECT id, unnest(topics) AS topics FROM repositories WHERE topics IS NOT NULL AND array_length(topics, 1) > 0) AS foo GROUP BY topics ORDER BY topics_count DESC, topics ASC LIMIT 50000;")
+      end
+    else
+      Rails.cache.fetch("host/#{self.id}/topics", expires_in: 1.week) do
+        Repository.connection.select_rows("SELECT topics, COUNT(topics) AS topics_count FROM (SELECT id, unnest(topics) AS topics FROM repositories WHERE topics IS NOT NULL AND array_length(topics, 1) > 0) AS foo GROUP BY topics ORDER BY topics_count DESC, topics ASC LIMIT 50000;")
+      end
     end
   end
 


### PR DESCRIPTION
When not prefixing with a host the route fail. It's the first route documented in the API so we fixed it instead of removing the route.