### PR TITLE
Forward synchro

### DIFF
--- a/app/models/hosts/gitlab.rb
+++ b/app/models/hosts/gitlab.rb
@@ -335,7 +335,7 @@ module Hosts
       end
       repos = api_client.projects(per_page: 100, archived: false, id_after: recent_id, simple: true)
       repos.reject! { |repo| repo.dig("namespace", "kind") == "user" } if ENV["SKIP_USER_REPOS"]
-      if repos.present?
+      if repos.present? && repos.any?
         repos.each { |repo| @host.sync_repository(repo["path_with_namespace"], uuid: repo["id"]) }
         REDIS.set("gitlab_recent_id:#{@host.id}", repos.last["id"])
       end

--- a/app/models/hosts/gitlab.rb
+++ b/app/models/hosts/gitlab.rb
@@ -48,8 +48,18 @@ module Hosts
         nil
       end
 
-      def projects(per_page:, archived:, id_before: nil, id_after: nil, simple:, page: 1, order_by: nil)
-        url = "#{@endpoint}/projects?per_page=#{per_page}&archived=#{archived}&id_before=#{id_before}&id_after=#{id_after}&simple=#{simple}&page=#{page}&order_by=#{order_by}"
+      def projects(per_page:, archived:, id_before: nil, id_after: nil, simple:, page: 1, order_by: nil, sort: nil)
+        if id_before
+          sort ||= "desc"
+          order_by ||= "id"
+        elsif id_after
+          sort ||= "asc"
+          order_by ||= "id"
+        else
+          sort ||= "desc"
+          order_by ||= "id"
+        end
+        url = "#{@endpoint}/projects?per_page=#{per_page}&archived=#{archived}&id_before=#{id_before}&id_after=#{id_after}&simple=#{simple}&page=#{page}&order_by=#{order_by}&sort=#{sort}"
         Rails.logger.debug("Gitlab[projects]: Fetching projects from URL: #{url}")
 
         response = faraday_client.get(url)
@@ -331,7 +341,7 @@ module Hosts
     def crawl_repositories_forward
       recent_id = REDIS.get("gitlab_recent_id:#{@host.id}")
       if recent_id.nil?
-        recent_id = @host.repositories.maximum(:id)
+        recent_id = @host.repositories.maximum(:uuid)
       end
       repos = api_client.projects(per_page: 100, archived: false, id_after: recent_id, simple: true)
       repos.reject! { |repo| repo.dig("namespace", "kind") == "user" } if ENV["SKIP_USER_REPOS"]

--- a/app/models/hosts/gitlab.rb
+++ b/app/models/hosts/gitlab.rb
@@ -304,16 +304,45 @@ module Hosts
     end
 
     def crawl_repositories
+      # legacy way to synchronize on ecosyste.ms
+      crawl_repositories_backwards
+    end
+
+    def crawl_repositories_two_ways
+      # new experimental way to synchronize
+      if ! crawl_repositories_backwards
+        crawl_repositories_forward
+      end
+    end
+
+    def crawl_repositories_backwards
       last_id = REDIS.get("gitlab_last_id:#{@host.id}")
       repos = api_client.projects(per_page: 100, archived: false, id_before: last_id, simple: true)
       if repos.present? && repos.any?
         repos.reject! { |repo| repo.dig("namespace", "kind") == "user" } if ENV["SKIP_USER_REPOS"]
         repos.each { |repo| @host.sync_repository(repo["path_with_namespace"], uuid: repo["id"]) }
         REDIS.set("gitlab_last_id:#{@host.id}", repos.last["id"])
+        return true
       end
     rescue *IGNORABLE_EXCEPTIONS
       nil
     end
+
+    def crawl_repositories_forward
+      recent_id = REDIS.get("gitlab_recent_id:#{@host.id}")
+      if recent_id.nil?
+        recent_id = @host.repositories.maximum(:id)
+      end
+      repos = api_client.projects(per_page: 100, archived: false, id_after: recent_id, simple: true)
+      repos.reject! { |repo| repo.dig("namespace", "kind") == "user" } if ENV["SKIP_USER_REPOS"]
+      if repos.present?
+        repos.each { |repo| @host.sync_repository(repo["path_with_namespace"], uuid: repo["id"]) }
+        REDIS.set("gitlab_recent_id:#{@host.id}", repos.last["id"])
+      end
+    rescue *IGNORABLE_EXCEPTIONS
+      nil
+    end
+
 
     def load_owner_repos_names(owner)
       if owner.user?

--- a/app/models/hosts/gitlab.rb
+++ b/app/models/hosts/gitlab.rb
@@ -48,8 +48,8 @@ module Hosts
         nil
       end
 
-      def projects(per_page:, archived:, id_before: nil, simple:, page: 1, order_by: nil)
-        url = "#{@endpoint}/projects?per_page=#{per_page}&archived=#{archived}&id_before=#{id_before}&simple=#{simple}&page=#{page}&order_by=#{order_by}"
+      def projects(per_page:, archived:, id_before: nil, id_after: nil, simple:, page: 1, order_by: nil)
+        url = "#{@endpoint}/projects?per_page=#{per_page}&archived=#{archived}&id_before=#{id_before}&id_after=#{id_after}&simple=#{simple}&page=#{page}&order_by=#{order_by}"
         Rails.logger.debug("Gitlab[projects]: Fetching projects from URL: #{url}")
 
         response = faraday_client.get(url)

--- a/lib/tasks/dinum.rake
+++ b/lib/tasks/dinum.rake
@@ -134,6 +134,9 @@ module Dinum
       sleep 1
       break if host.reload.repositories_count == repo_count
     end
+    host.owners.each do |owner|
+      owner.update_repositories_count
+    end
   end
 
   # Method to perform a full synchronization for all pso hosts

--- a/lib/tasks/dinum.rake
+++ b/lib/tasks/dinum.rake
@@ -130,7 +130,7 @@ module Dinum
     host_reset(host) if host.repositories_count == 0
     loop do
       repo_count = host.repositories_count
-      host.crawl_repositories
+      host.crawl_repositories_two_ways
       sleep 1
       break if host.reload.repositories_count == repo_count
     end


### PR DESCRIPTION
As discussed, we first synchronise backward from most recent project (at first synchronisation) to the oldest one, when it's done we synchronise forward starting at the most recent project (at each synchronisation).

More explicit sortering in projects api on anonymous gitlab client