### PR TITLE
Stop eager loading dependencies in dependency parsing workers

### DIFF
--- a/app/sidekiq/parse_dependencies_worker.rb
+++ b/app/sidekiq/parse_dependencies_worker.rb
@@ -3,6 +3,6 @@ class ParseDependenciesWorker
   sidekiq_options queue: 'dependencies', lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(repository_id)
-    Repository.find_by_id(repository_id).try(:parse_dependencies)
+    Repository.includes(:manifests).find_by_id(repository_id).try(:parse_dependencies)
   end
 end

--- a/app/sidekiq/parse_dependencies_worker.rb
+++ b/app/sidekiq/parse_dependencies_worker.rb
@@ -3,6 +3,6 @@ class ParseDependenciesWorker
   sidekiq_options queue: 'dependencies', lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(repository_id)
-    Repository.includes(manifests: :dependencies).find_by_id(repository_id).try(:parse_dependencies)
+    Repository.find_by_id(repository_id).try(:parse_dependencies)
   end
 end

--- a/app/sidekiq/parse_tag_dependencies_worker.rb
+++ b/app/sidekiq/parse_tag_dependencies_worker.rb
@@ -3,6 +3,6 @@ class ParseTagDependenciesWorker
   sidekiq_options queue: 'dependencies', lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(tag_id)
-    Tag.find_by_id(tag_id).try(:parse_dependencies)
+    Tag.includes(:manifests).find_by_id(tag_id).try(:parse_dependencies)
   end
 end

--- a/app/sidekiq/parse_tag_dependencies_worker.rb
+++ b/app/sidekiq/parse_tag_dependencies_worker.rb
@@ -3,6 +3,6 @@ class ParseTagDependenciesWorker
   sidekiq_options queue: 'dependencies', lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(tag_id)
-    Tag.includes(manifests: :dependencies).find_by_id(tag_id).try(:parse_dependencies)
+    Tag.find_by_id(tag_id).try(:parse_dependencies)
   end
 end

--- a/test/workers/parse_dependencies_worker_test.rb
+++ b/test/workers/parse_dependencies_worker_test.rb
@@ -20,7 +20,7 @@ class ParseDependenciesWorkerTest < ActiveSupport::TestCase
       end
     end
 
-    should 'not eager load manifests and dependencies' do
+    should 'eager load manifests but not dependencies' do
       host = create(:host)
       repository = create(:repository, host: host)
       manifest = create(:manifest, repository: repository)
@@ -37,8 +37,10 @@ class ParseDependenciesWorkerTest < ActiveSupport::TestCase
         ParseDependenciesWorker.new.perform(repository.id)
       end
 
-      eager_load_queries = queries.select { |q| q.include?('manifests') || q.include?('dependencies') }
-      assert_empty eager_load_queries, "Should not eager load manifests or dependencies"
+      manifest_queries = queries.select { |q| q.include?('manifests') }
+      dependency_queries = queries.select { |q| q.include?('dependencies') }
+      assert manifest_queries.any?, "Should eager load manifests"
+      assert_empty dependency_queries, "Should not eager load dependencies"
     end
   end
 end

--- a/test/workers/parse_dependencies_worker_test.rb
+++ b/test/workers/parse_dependencies_worker_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class ParseDependenciesWorkerTest < ActiveSupport::TestCase
+  context '#perform' do
+    should 'call parse_dependencies on repository' do
+      host = create(:host)
+      repository = create(:repository, host: host)
+
+      Repository.any_instance.expects(:parse_dependencies).once
+
+      worker = ParseDependenciesWorker.new
+      worker.perform(repository.id)
+    end
+
+    should 'handle non-existent repository gracefully' do
+      worker = ParseDependenciesWorker.new
+
+      assert_nothing_raised do
+        worker.perform(999999)
+      end
+    end
+
+    should 'not eager load manifests and dependencies' do
+      host = create(:host)
+      repository = create(:repository, host: host)
+      manifest = create(:manifest, repository: repository)
+      create(:dependency, repository: repository, manifest: manifest)
+
+      Repository.any_instance.stubs(:parse_dependencies)
+
+      queries = []
+      callback = lambda { |_name, _start, _finish, _id, payload|
+        queries << payload[:sql] if payload[:sql].present?
+      }
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        ParseDependenciesWorker.new.perform(repository.id)
+      end
+
+      eager_load_queries = queries.select { |q| q.include?('manifests') || q.include?('dependencies') }
+      assert_empty eager_load_queries, "Should not eager load manifests or dependencies"
+    end
+  end
+end

--- a/test/workers/parse_tag_dependencies_worker_test.rb
+++ b/test/workers/parse_tag_dependencies_worker_test.rb
@@ -21,7 +21,7 @@ class ParseTagDependenciesWorkerTest < ActiveSupport::TestCase
       end
     end
 
-    should 'not eager load manifests and dependencies' do
+    should 'eager load manifests but not dependencies' do
       host = create(:host)
       repository = create(:repository, host: host)
       tag = create(:tag, repository: repository)
@@ -38,8 +38,10 @@ class ParseTagDependenciesWorkerTest < ActiveSupport::TestCase
         ParseTagDependenciesWorker.new.perform(tag.id)
       end
 
-      eager_load_queries = queries.select { |q| q.include?('manifests') || q.include?('dependencies') }
-      assert_empty eager_load_queries, "Should not eager load manifests or dependencies"
+      manifest_queries = queries.select { |q| q.include?('manifests') }
+      dependency_queries = queries.select { |q| q.include?('dependencies') }
+      assert manifest_queries.any?, "Should eager load manifests"
+      assert_empty dependency_queries, "Should not eager load dependencies"
     end
   end
 end

--- a/test/workers/parse_tag_dependencies_worker_test.rb
+++ b/test/workers/parse_tag_dependencies_worker_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class ParseTagDependenciesWorkerTest < ActiveSupport::TestCase
+  context '#perform' do
+    should 'call parse_dependencies on tag' do
+      host = create(:host)
+      repository = create(:repository, host: host)
+      tag = create(:tag, repository: repository)
+
+      Tag.any_instance.expects(:parse_dependencies).once
+
+      worker = ParseTagDependenciesWorker.new
+      worker.perform(tag.id)
+    end
+
+    should 'handle non-existent tag gracefully' do
+      worker = ParseTagDependenciesWorker.new
+
+      assert_nothing_raised do
+        worker.perform(999999)
+      end
+    end
+
+    should 'not eager load manifests and dependencies' do
+      host = create(:host)
+      repository = create(:repository, host: host)
+      tag = create(:tag, repository: repository)
+      create(:manifest, tag: tag, repository: nil)
+
+      Tag.any_instance.stubs(:parse_dependencies)
+
+      queries = []
+      callback = lambda { |_name, _start, _finish, _id, payload|
+        queries << payload[:sql] if payload[:sql].present?
+      }
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        ParseTagDependenciesWorker.new.perform(tag.id)
+      end
+
+      eager_load_queries = queries.select { |q| q.include?('manifests') || q.include?('dependencies') }
+      assert_empty eager_load_queries, "Should not eager load manifests or dependencies"
+    end
+  end
+end


### PR DESCRIPTION
ParseDependenciesWorker and ParseTagDependenciesWorker used `includes(manifests: :dependencies)` which loads all dependency rows into memory. The manifests eager load is needed by `sync_manifest` and `delete_old_manifests`, but the nested `:dependencies` load is never read. For repositories with many dependencies this can consume several GB of memory.

Changed to `includes(:manifests)` to keep the manifests preloaded while avoiding loading dependency rows.