### PR TITLE
Add SourceForge host support

### DIFF
--- a/app/models/hosts/sourceforge.rb
+++ b/app/models/hosts/sourceforge.rb
@@ -1,0 +1,98 @@
+module Hosts
+  class Sourceforge < Base
+    IGNORABLE_EXCEPTIONS = [
+      Faraday::ResourceNotFound
+    ]
+
+    def self.api_missing_error_class
+      Faraday::ResourceNotFound
+    end
+
+    def icon
+      'sourceforge'
+    end
+
+    def url(repository)
+      "#{@host.url}/projects/#{repository.full_name}"
+    end
+
+    def html_url(repository)
+      url(repository)
+    end
+
+    def issues_url(repository)
+      "#{@host.url}/p/#{repository.full_name}/tickets/"
+    end
+
+    def source_url(repository)
+      "#{@host.url}/p/#{repository.source_name}/" if repository.source_name.present?
+    end
+
+    def download_url(repository, branch = nil, kind = 'branch')
+      "#{@host.url}/projects/#{repository.full_name}/files/latest/download"
+    end
+
+    def fetch_repository(full_name)
+      return nil if full_name.blank?
+
+      response = api_client.get("/rest/p/#{CGI.escape(full_name)}/")
+      return nil unless response.success? && response.body.is_a?(Hash)
+
+      project = response.body
+      return nil if project.blank? || project['private']
+
+      map_repository_data(project)
+    rescue *IGNORABLE_EXCEPTIONS
+      nil
+    end
+
+    def map_repository_data(project)
+      {
+        uuid: project['_id'],
+        full_name: project['shortname'],
+        owner: project['shortname'],
+        description: project['short_description'].presence || project['summary'],
+        homepage: project['external_homepage'].presence,
+        fork: false,
+        created_at: project['creation_date'],
+        updated_at: project['last_updated'],
+        pushed_at: project['last_updated'],
+        has_issues: true,
+        private: project['private'],
+        scm: 'unknown',
+        pull_requests_enabled: false,
+        logo_url: project['icon_url'],
+        topics: Array(project['labels']).compact,
+        archived: false
+      }
+    end
+
+    def recently_changed_repo_names(_since = 1.hour)
+      []
+    end
+
+    def crawl_repositories_async
+      # SourceForge does not expose a simple recent-projects endpoint suitable
+      # for incremental crawling. Repositories are synced on demand instead.
+      nil
+    end
+
+    def crawl_repositories
+      nil
+    end
+
+    def download_tags(_repository)
+      nil
+    end
+
+    def download_releases(_repository)
+      nil
+    end
+
+    def api_client
+      Faraday.new(@host.url, request: { timeout: 30 }) do |conn|
+        conn.response :json
+      end
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,6 +3,7 @@ default_hosts = [
   {name: 'GitLab.com', url: 'https://gitlab.com', kind: 'gitlab'},
   {name: 'Bitbucket.org', url: 'https://bitbucket.org', kind: 'bitbucket'},
   {name: 'SourceHut', url: 'https://sr.ht', kind: 'sourcehut'},
+  {name: 'SourceForge', url: 'https://sourceforge.net', kind: 'sourceforge'},
   {name: 'Gitea.com', url: 'https://gitea.com', kind: 'gitea'},
   {name: "Codeberg.org", url: "https://codeberg.org", kind: "forgejo", org: 'Codeberg-org'},
   {name: "git.fsfe.org", url: "https://git.fsfe.org", kind: "gitea", org: 'fsfe'},

--- a/test/models/hosts/sourceforge_test.rb
+++ b/test/models/hosts/sourceforge_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+class Hosts::SourceforgeTest < ActiveSupport::TestCase
+  setup do
+    @host = create(:host, name: 'SourceForge', url: 'https://sourceforge.net', kind: 'sourceforge')
+    @sourceforge = Hosts::Sourceforge.new(@host)
+  end
+
+  should 'map public project metadata to repository attributes' do
+    stub_request(:get, "https://sourceforge.net/rest/p/sevenzip/")
+      .to_return(
+        status: 200,
+        headers: { 'Content-Type' => 'application/json' },
+        body: {
+          '_id' => '50c218025fcbc909b58b271b',
+          'shortname' => 'sevenzip',
+          'name' => '7-Zip',
+          'private' => false,
+          'short_description' => 'A file archiver',
+          'summary' => '7-Zip summary',
+          'external_homepage' => 'https://www.7-zip.org/',
+          'creation_date' => '2000-01-01',
+          'last_updated' => '2026-04-01T00:00:00Z',
+          'icon_url' => 'https://sourceforge.net/p/sevenzip/icon',
+          'labels' => ['compression', 'archive']
+        }.to_json
+      )
+
+    repo = @sourceforge.fetch_repository('sevenzip')
+
+    assert_equal '50c218025fcbc909b58b271b', repo[:uuid]
+    assert_equal 'sevenzip', repo[:full_name]
+    assert_equal 'sevenzip', repo[:owner]
+    assert_equal 'A file archiver', repo[:description]
+    assert_equal 'https://www.7-zip.org/', repo[:homepage]
+    assert_equal false, repo[:private]
+    assert_equal false, repo[:fork]
+    assert_equal false, repo[:pull_requests_enabled]
+    assert_equal ['compression', 'archive'], repo[:topics]
+  end
+
+  should 'skip private projects' do
+    stub_request(:get, "https://sourceforge.net/rest/p/privateproj/")
+      .to_return(
+        status: 200,
+        headers: { 'Content-Type' => 'application/json' },
+        body: { 'shortname' => 'privateproj', 'private' => true }.to_json
+      )
+
+    assert_nil @sourceforge.fetch_repository('privateproj')
+  end
+
+  should 'build project urls' do
+    repository = build(:repository, host: @host, full_name: 'sevenzip')
+
+    assert_equal 'https://sourceforge.net/projects/sevenzip', @sourceforge.url(repository)
+    assert_equal 'https://sourceforge.net/projects/sevenzip/files/latest/download', @sourceforge.download_url(repository)
+    assert_equal 'https://sourceforge.net/p/sevenzip/tickets/', @sourceforge.issues_url(repository)
+  end
+end


### PR DESCRIPTION
## Summary
- add a SourceForge host adapter backed by the SourceForge project REST endpoint
- seed SourceForge as a default host
- add host tests for metadata mapping, private project skipping, and generated project/download/ticket URLs

Refs #219

## Validation
- `ruby -c app/models/hosts/sourceforge.rb`
- `ruby -c test/models/hosts/sourceforge_test.rb`
- `git diff --check`

Note: full test execution is blocked locally because the current lockfile requires Bundler 4.0.10 and `bundle install` fails on the yanked `sitemap_generator (7.0.0)` gem.