### PR TITLE
Add Gogs host support

### DIFF
--- a/app/models/hosts/gogs.rb
+++ b/app/models/hosts/gogs.rb
@@ -1,0 +1,18 @@
+module Hosts
+  class Gogs < Gitea
+    def icon
+      'gogs'
+    end
+
+    def fetch_topics(_full_name)
+      []
+    end
+
+    def api_client
+      Faraday.new(@host.url, request: { timeout: 30 }) do |conn|
+        conn.request :authorization, :bearer, REDIS.get("gogs_token:#{@host.id}")
+        conn.response :json
+      end
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,6 +4,7 @@ default_hosts = [
   {name: 'Bitbucket.org', url: 'https://bitbucket.org', kind: 'bitbucket'},
   {name: 'SourceHut', url: 'https://sr.ht', kind: 'sourcehut'},
   {name: 'Gitea.com', url: 'https://gitea.com', kind: 'gitea'},
+  {name: 'Gogs', url: 'https://try.gogs.io', kind: 'gogs'},
   {name: "Codeberg.org", url: "https://codeberg.org", kind: "forgejo", org: 'Codeberg-org'},
   {name: "git.fsfe.org", url: "https://git.fsfe.org", kind: "gitea", org: 'fsfe'},
   {name: "opendev.org", url: "https://opendev.org", kind: "gitea", org: 'openstack-infra'},

--- a/test/models/hosts/gogs_test.rb
+++ b/test/models/hosts/gogs_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class Hosts::GogsTest < ActiveSupport::TestCase
+  setup do
+    @host = create(:host, name: 'Gogs', url: 'https://try.gogs.io', kind: 'gogs')
+    @gogs = Hosts::Gogs.new(@host)
+  end
+
+  should 'use gogs icon' do
+    assert_equal 'gogs', @gogs.icon
+  end
+
+  should 'map repository data using the Gitea-compatible API shape' do
+    data = {
+      'id' => 123,
+      'full_name' => 'gogs/gogs',
+      'owner' => { 'login' => 'gogs', 'avatar_url' => 'https://try.gogs.io/avatars/1' },
+      'language' => 'Go',
+      'archived' => false,
+      'fork' => false,
+      'description' => 'Gogs repository',
+      'size' => 42,
+      'stars_count' => 100,
+      'open_issues_count' => 2,
+      'forks_count' => 3,
+      'default_branch' => 'main',
+      'website' => 'https://gogs.io',
+      'has_issues' => true,
+      'has_wiki' => true,
+      'mirror' => false,
+      'private' => false,
+      'has_pull_requests' => true,
+      'avatar_url' => nil,
+      'created_at' => '2026-01-01T00:00:00Z',
+      'updated_at' => '2026-01-02T00:00:00Z'
+    }
+
+    repo = @gogs.map_repository_data(data)
+
+    assert_equal 123, repo[:uuid]
+    assert_equal 'gogs/gogs', repo[:full_name]
+    assert_equal 'gogs', repo[:owner]
+    assert_equal 'Go', repo[:language]
+    assert_equal 'git', repo[:scm]
+    assert_equal true, repo[:pull_requests_enabled]
+    assert_equal [], repo[:topics]
+    assert_equal 'https://try.gogs.io/avatars/1', repo[:logo_url]
+  end
+end


### PR DESCRIPTION
## Summary
- add a `Hosts::Gogs` adapter using the existing Gitea-compatible host behavior
- skip topics for Gogs because older Gogs APIs do not expose the Gitea topics endpoint consistently
- seed a default Gogs host entry and add model coverage for mapping the Gogs/Gitea-compatible repository payload

Refs #47

## Validation
- `ruby -c app/models/hosts/gogs.rb`
- `ruby -c test/models/hosts/gogs_test.rb`
- `git diff --check`

Note: full test execution is blocked locally because this repo currently requires Bundler 4.0.10 and bundle install fails on the yanked `sitemap_generator (7.0.0)` gem.