### PR TITLE
Add OneDev host support

### DIFF
--- a/app/models/hosts/onedev.rb
+++ b/app/models/hosts/onedev.rb
@@ -1,0 +1,153 @@
+module Hosts
+  class Onedev < Base
+    IGNORABLE_EXCEPTIONS = [Faraday::ResourceNotFound, Faraday::UnauthorizedError, Faraday::ForbiddenError]
+
+    def self.api_missing_error_class
+      Faraday::ResourceNotFound
+    end
+
+    def icon
+      'onedev'
+    end
+
+    def url(repository)
+      "#{@host.url}/#{repository.full_name}"
+    end
+
+    def blob_url(repository, sha = nil)
+      sha ||= repository.default_branch.presence || 'main'
+      "#{url(repository)}/~files/#{CGI.escape(sha)}/"
+    end
+
+    def raw_url(repository, sha = nil)
+      sha ||= repository.default_branch.presence || 'main'
+      "#{url(repository)}/~raw/#{CGI.escape(sha)}/"
+    end
+
+    def tag_url(repository, tag_name)
+      "#{url(repository)}/~files/#{CGI.escape(tag_name)}"
+    end
+
+    def recently_changed_repo_names(since = 1.hour)
+      projects = query_projects('order by "Update Date" desc')
+      cutoff = Time.now - since
+      projects.take_while { |project| parse_time(project['updateDate'])&.> cutoff }.map { |project| project['path'] }.compact
+    rescue *IGNORABLE_EXCEPTIONS
+      []
+    end
+
+    def load_owner_repos_names(owner)
+      query_projects(%("Path" is "#{owner.login}/**")).map { |project| project['path'] }.compact
+    rescue *IGNORABLE_EXCEPTIONS
+      []
+    end
+
+    def crawl_repositories
+      offset = (REDIS.get("onedev_last_offset:#{@host.id}") || 0).to_i
+      repos = query_projects(nil, offset)
+      return unless repos.present?
+      repos.each { |repo| @host.sync_repository(repo['path']) if repo['path'].present? }
+      REDIS.set("onedev_last_offset:#{@host.id}", offset + repos.length)
+    rescue Faraday::Error
+      nil
+    end
+
+    def crawl_repositories_async
+      offset = (REDIS.get("onedev_last_offset:#{@host.id}") || 0).to_i
+      repos = query_projects(nil, offset)
+      return unless repos.present?
+      repos.each { |repo| @host.sync_repository_async(repo['path']) if repo['path'].present? }
+      REDIS.set("onedev_last_offset:#{@host.id}", offset + repos.length)
+    rescue Faraday::Error
+      nil
+    end
+
+    def fetch_repository(id_or_name)
+      project_id = id_or_name.to_s.match?(/\A\d+\z/) ? id_or_name : project_id_for_path(id_or_name)
+      return nil unless project_id
+
+      resp = api_client.get("~api/projects/#{project_id}")
+      return nil unless resp.success? && resp.body.present?
+
+      data = resp.body
+      data['defaultBranch'] ||= fetch_default_branch(project_id)
+      map_repository_data(data)
+    rescue Faraday::Error
+      nil
+    end
+
+    def map_repository_data(data)
+      full_name = data['path'].presence || data['name']
+      owner = full_name.to_s.split('/')[0...-1].join('/')
+      {
+        uuid: data['id'],
+        full_name: full_name,
+        owner: owner.presence,
+        description: data['description'],
+        fork: data['forkedFromId'].present?,
+        created_at: data['createDate'],
+        updated_at: data['updateDate'],
+        default_branch: data['defaultBranch'],
+        has_issues: data['issueManagement'],
+        pull_requests_enabled: data['codeManagement'],
+        private: false,
+        scm: 'git',
+        source_name: fetch_source_path(data['forkedFromId']),
+        topics: [],
+      }
+    end
+
+    def fetch_owner(login)
+      {
+        uuid: login,
+        login: login,
+        name: login,
+        kind: 'organization'
+      }
+    end
+
+    def api_client
+      Faraday.new(@host.url, request: { timeout: 30 }) do |conn|
+        token = REDIS.get("onedev_token:#{@host.id}")
+        conn.request :authorization, :bearer, token if token.present?
+        conn.response :json
+      end
+    end
+
+    private
+
+    def query_projects(query = nil, offset = 0, count = 100)
+      params = { offset: offset, count: count }
+      params[:query] = query if query.present?
+      resp = api_client.get('~api/projects', params)
+      return [] unless resp.success?
+      resp.body.is_a?(Array) ? resp.body : []
+    end
+
+    def project_id_for_path(path)
+      resp = api_client.get("~api/projects/ids/#{path}")
+      resp.success? ? resp.body : nil
+    end
+
+    def fetch_default_branch(project_id)
+      resp = api_client.get("~api/repositories/#{project_id}/default-branch")
+      resp.success? ? resp.body : nil
+    rescue Faraday::Error
+      nil
+    end
+
+    def fetch_source_path(project_id)
+      return nil if project_id.blank?
+      resp = api_client.get("~api/projects/#{project_id}")
+      resp.success? ? resp.body['path'] : nil
+    rescue Faraday::Error
+      nil
+    end
+
+    def parse_time(value)
+      Time.parse(value.to_s) if value.present?
+    rescue ArgumentError
+      nil
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,6 +4,7 @@ default_hosts = [
   {name: 'Bitbucket.org', url: 'https://bitbucket.org', kind: 'bitbucket'},
   {name: 'SourceHut', url: 'https://sr.ht', kind: 'sourcehut'},
   {name: 'Gitea.com', url: 'https://gitea.com', kind: 'gitea'},
+  {name: 'OneDev', url: 'https://code.onedev.io', kind: 'onedev'},
   {name: "Codeberg.org", url: "https://codeberg.org", kind: "forgejo", org: 'Codeberg-org'},
   {name: "git.fsfe.org", url: "https://git.fsfe.org", kind: "gitea", org: 'fsfe'},
   {name: "opendev.org", url: "https://opendev.org", kind: "gitea", org: 'openstack-infra'},

--- a/test/models/hosts/onedev_test.rb
+++ b/test/models/hosts/onedev_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class Hosts::OnedevTest < ActiveSupport::TestCase
+  setup do
+    @host = create(:host, name: 'OneDev', url: 'https://code.onedev.io', kind: 'onedev')
+    @onedev = Hosts::Onedev.new(@host)
+  end
+
+  should 'use onedev icon' do
+    assert_equal 'onedev', @onedev.icon
+  end
+
+  should 'build OneDev file URLs' do
+    repository = build(:repository, host: @host, full_name: 'onedev/server', default_branch: 'main')
+
+    assert_equal 'https://code.onedev.io/onedev/server/~files/main/', @onedev.blob_url(repository)
+    assert_equal 'https://code.onedev.io/onedev/server/~raw/main/', @onedev.raw_url(repository)
+    assert_equal 'https://code.onedev.io/onedev/server/~files/v1.0.0', @onedev.tag_url(repository, 'v1.0.0')
+  end
+
+  should 'map project data from OneDev API' do
+    @onedev.stubs(:fetch_source_path).with(7).returns('upstream/project')
+
+    repo = @onedev.map_repository_data({
+      'id' => 123,
+      'path' => 'onedev/server',
+      'description' => 'Self-hosted git server',
+      'forkedFromId' => 7,
+      'createDate' => '2026-01-01T00:00:00Z',
+      'updateDate' => '2026-01-02T00:00:00Z',
+      'defaultBranch' => 'main',
+      'codeManagement' => true,
+      'issueManagement' => true
+    })
+
+    assert_equal 123, repo[:uuid]
+    assert_equal 'onedev/server', repo[:full_name]
+    assert_equal 'onedev', repo[:owner]
+    assert_equal 'Self-hosted git server', repo[:description]
+    assert_equal true, repo[:fork]
+    assert_equal 'main', repo[:default_branch]
+    assert_equal true, repo[:has_issues]
+    assert_equal true, repo[:pull_requests_enabled]
+    assert_equal 'git', repo[:scm]
+    assert_equal 'upstream/project', repo[:source_name]
+    assert_equal [], repo[:topics]
+  end
+end


### PR DESCRIPTION
## Summary
- add a OneDev host adapter backed by OneDev's REST API
- support project lookup by path/id, repository crawling, owner repository listing, default branch lookup, and OneDev file/raw/tag URLs
- seed the public code.onedev.io instance as a default host
- add model coverage for URL generation and OneDev project payload mapping

Refs #46

## Validation
- `ruby -c app/models/hosts/onedev.rb`
- `ruby -c test/models/hosts/onedev_test.rb`
- `git diff --check`

Full test execution is still locally blocked because this repo requires Bundler 4.0.10 and `bundle install` fails on the yanked `sitemap_generator (7.0.0)` dependency.