### PR TITLE
Add RSS and Atom repository feeds

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -23,6 +23,12 @@ class HostsController < ApplicationController
 
     @pagy, @repositories = pagy_countless(scope)
     expires_in 1.day, public: true
+
+    respond_to do |format|
+      format.html
+      format.rss
+      format.atom
+    end
   end
 
   def kind

--- a/app/views/hosts/show.atom.builder
+++ b/app/views/hosts/show.atom.builder
@@ -1,0 +1,18 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.feed xmlns: 'http://www.w3.org/2005/Atom' do
+  xml.title "#{@host.name} repositories"
+  xml.subtitle "Latest repositories indexed for #{@host.name}"
+  xml.id host_url(@host)
+  xml.link href: host_url(@host)
+  xml.link href: host_url(@host, format: :atom), rel: 'self', type: 'application/atom+xml'
+  xml.updated((@repositories.first&.updated_at || Time.current).iso8601)
+
+  @repositories.each do |repository|
+    xml.entry do
+      xml.title repository.full_name
+      xml.id host_repository_url(@host, repository.full_name)
+      xml.link href: host_repository_url(@host, repository.full_name)
+      xml.updated((repository.updated_at || Time.current).iso8601)
+    end
+  end
+end

--- a/app/views/hosts/show.html.erb
+++ b/app/views/hosts/show.html.erb
@@ -1,3 +1,8 @@
+<% content_for :head do %>
+  <%= auto_discovery_link_tag(:rss, host_url(@host, request.query_parameters.merge(format: :rss)), title: "Repository List RSS") %>
+  <%= auto_discovery_link_tag(:atom, host_url(@host, request.query_parameters.merge(format: :atom)), title: "Repository List Atom") %>
+<% end %>
+
 <% @meta_title = @host.to_s %>
 <% @meta_description = "Repositories of #{@host}" %>
 

--- a/app/views/hosts/show.rss.builder
+++ b/app/views/hosts/show.rss.builder
@@ -1,0 +1,18 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.rss version: '2.0' do
+  xml.channel do
+    xml.title "#{@host.name} repositories"
+    xml.description "Latest repositories indexed for #{@host.name}"
+    xml.link host_url(@host)
+    xml.language 'en'
+
+    @repositories.each do |repository|
+      xml.item do
+        xml.title repository.full_name
+        xml.link host_repository_url(@host, repository.full_name)
+        xml.guid host_repository_url(@host, repository.full_name), isPermaLink: true
+        xml.pubDate repository.updated_at.rfc2822 if repository.updated_at.present?
+      end
+    end
+  end
+end

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -20,6 +20,33 @@ class HostsControllerTest < ActionDispatch::IntegrationTest
     assert_template 'hosts/show', file: 'hosts/show.html.erb'
   end
 
+
+  test 'host page provides RSS and Atom discovery links' do
+    get host_path(id: @host.name)
+
+    assert_response :success
+    assert_select 'link[rel="alternate"][type="application/rss+xml"]'
+    assert_select 'link[rel="alternate"][type="application/atom+xml"]'
+  end
+
+  test 'renders host repositories RSS feed' do
+    get host_path(id: @host.name, format: :rss)
+
+    assert_response :success
+    assert_equal 'application/rss+xml', response.media_type
+    assert_includes response.body, '<rss'
+    assert_includes response.body, @repo.full_name
+  end
+
+  test 'renders host repositories Atom feed' do
+    get host_path(id: @host.name, format: :atom)
+
+    assert_response :success
+    assert_equal 'application/atom+xml', response.media_type
+    assert_includes response.body, '<feed'
+    assert_includes response.body, @repo.full_name
+  end
+
   test 'topic route with simple topic' do
     skip "TODO(DB_PERF): hosts#topic disabled 2026-01-10"
     get topic_host_path(id: @host.name, topic: 'ruby')


### PR DESCRIPTION
Refs #209

## Summary
- adds RSS and Atom feed responses for host repository list pages
- adds feed auto-discovery links in the HTML head for host repository lists
- adds controller coverage for discovery links and feed responses

## Validation
- `ruby -c app/controllers/hosts_controller.rb`
- `ruby -c app/views/hosts/show.rss.builder`
- `ruby -c app/views/hosts/show.atom.builder`
- `ruby -c test/controllers/hosts_controller_test.rb`
- `git diff --check`

Full controller test execution is locally blocked because the lockfile requires Bundler 4.0.10 and this system Ruby cannot activate it.