### PR TITLE
Surface README badges in repository metadata

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -397,6 +397,42 @@ class Repository < ApplicationRecord
     metadata["files"] = metadata_files
     save
     parse_funding
+    parse_readme_badges
+  end
+
+  README_BADGE_IMAGE_PATTERN = /!\[[^\]]*\]\(([^\s\)]+)(?:\s+"[^"]*")?\)|<img\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/i
+
+  def parse_readme_badges
+    return if metadata["files"].blank?
+    return if metadata["files"]["readme"].blank?
+
+    file = get_file_contents(metadata["files"]["readme"])
+    return if file.blank?
+
+    badges = extract_readme_badges(file[:content])
+    metadata["badges"] = badges if badges.any?
+    save
+  rescue
+    nil
+  end
+
+  def extract_readme_badges(content)
+    return [] if content.blank?
+
+    content.scan(README_BADGE_IMAGE_PATTERN).flatten.compact.map do |url|
+      normalize_badge_url(url)
+    end.compact.uniq
+  end
+
+  def normalize_badge_url(url)
+    url = url.to_s.strip
+    return if url.blank?
+    return unless url.match?(/badge|shield|unmaintained\.tech/i)
+
+    uri = URI.parse(url)
+    return url if uri.is_a?(URI::HTTP)
+  rescue URI::InvalidURIError
+    nil
   end
 
   def parse_funding

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -1021,3 +1021,22 @@ class RepositoryTest < ActiveSupport::TestCase
     end
   end
 end
+
+class RepositoryReadmeBadgesTest < ActiveSupport::TestCase
+  test 'extract_readme_badges returns badge image URLs from markdown and html' do
+    repository = Repository.new
+    readme = <<~README
+      # Example
+      [![Build](https://img.shields.io/github/actions/workflow/status/example/repo/ci.yml)](https://github.com/example/repo/actions)
+      ![Unmaintained](https://unmaintained.tech/badge.svg)
+      <img alt="coverage" src="https://badgen.net/badge/coverage/95%25/green">
+      ![logo](https://example.com/logo.png)
+    README
+
+    assert_equal [
+      'https://img.shields.io/github/actions/workflow/status/example/repo/ci.yml',
+      'https://unmaintained.tech/badge.svg',
+      'https://badgen.net/badge/coverage/95%25/green'
+    ], repository.extract_readme_badges(readme)
+  end
+end


### PR DESCRIPTION
Refs #490

## Summary

- Extracts badge-like image URLs from README files during metadata file updates.
- Stores deduplicated badge URLs under `metadata["badges"]` so API consumers can surface signals such as unmaintained.tech.
- Supports Markdown image syntax and HTML `<img>` tags, with coverage for badge filtering.

## Validation

- `ruby -c app/models/repository.rb`
- `ruby -c test/models/repository_test.rb`
- `git diff --check`

`bundle exec ruby -Itest test/models/repository_test.rb -n '/extract_readme_badges/'` is blocked locally because this checkout requires Bundler 4.0.10 from `Gemfile.lock`, which is not available in the system Ruby environment.