### PR TITLE
Add cgit host support

### DIFF
--- a/app/models/hosts/cgit.rb
+++ b/app/models/hosts/cgit.rb
@@ -1,0 +1,113 @@
+module Hosts
+  class Cgit < Base
+    IGNORABLE_EXCEPTIONS = [Faraday::ResourceNotFound, Faraday::ConnectionFailed, Faraday::TimeoutError]
+
+    def self.api_missing_error_class
+      Faraday::ResourceNotFound
+    end
+
+    def icon
+      'git'
+    end
+
+    def url(repository)
+      "#{@host.url.to_s.chomp('/')}/#{repository.full_name}"
+    end
+
+    def html_url(repository)
+      url(repository)
+    end
+
+    def raw_url(repository, sha = nil)
+      sha ||= repository.default_branch.presence || 'master'
+      "#{url(repository)}/plain/?h=#{CGI.escape(sha)}"
+    end
+
+    def blob_url(repository, sha = nil)
+      raw_url(repository, sha)
+    end
+
+    def download_url(repository, branch = nil, kind = 'branch')
+      ref = branch.presence || repository.default_branch.presence || 'master'
+      "#{url(repository)}/snapshot/#{File.basename(repository.full_name)}-#{CGI.escape(ref)}.tar.gz"
+    end
+
+    def fetch_repository(id_or_name, _token = nil)
+      full_name = id_or_name.to_s.sub(%r{\A/}, '').sub(%r{/\z}, '')
+      resp = host_http_client("/#{full_name}/")
+      return nil unless resp.success?
+
+      map_repository_data(full_name, resp.body)
+    rescue *IGNORABLE_EXCEPTIONS
+      nil
+    end
+
+    def map_repository_data(full_name, html)
+      doc = Nokogiri::HTML(html)
+      title = doc.at('title')&.text.to_s.strip
+      repo_name, description = title.split(' - ', 2)
+      repo_name = File.basename(full_name) if repo_name.blank?
+      default_branch = doc.at('link[rel="alternate"][type="application/atom+xml"]')&.[]('href').to_s[/[?&]h=([^&]+)/, 1]
+
+      {
+        uuid: full_name,
+        full_name: full_name,
+        owner: cgit_owner(full_name),
+        description: description.presence,
+        default_branch: default_branch.presence || 'master',
+        fork: false,
+        archived: false,
+        private: false,
+        scm: 'git',
+        has_issues: false,
+        has_wiki: false,
+        pull_requests_enabled: false,
+        topics: [],
+        license: nil,
+        homepage: nil,
+        created_at: nil,
+        updated_at: nil,
+        pushed_at: nil,
+        metadata: {
+          cgit_name: repo_name,
+          generator: doc.at('meta[name="generator"]')&.[]('content')
+        }.compact
+      }
+    end
+
+    def load_repo_names(_page = nil, _order = nil)
+      resp = host_http_client('/')
+      return [] unless resp.success?
+
+      Nokogiri::HTML(resp.body).css('a').map { |a| a['href'].to_s }.filter_map do |href|
+        next unless href.match?(%r{/[^/?]+/?\z})
+        href.sub(%r{\A/}, '').sub(%r{/\z}, '')
+      end.uniq
+    rescue *IGNORABLE_EXCEPTIONS
+      []
+    end
+
+    def crawl_repositories
+      load_repo_names.each { |name| @host.sync_repository(name) }
+    end
+
+    def crawl_repositories_async
+      load_repo_names.each { |name| @host.sync_repository_async(name) }
+    end
+
+    def download_tags(repository)
+      nil
+    end
+
+    def download_releases(repository)
+      nil
+    end
+
+    private
+
+    def cgit_owner(full_name)
+      parts = full_name.split('/')
+      return parts[-2] if parts.length > 1
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,13 @@
 default_hosts = [
+  {name: 'git.kernel.org', url: 'https://git.kernel.org', kind: 'cgit'},
+  {name: 'git.zx2c4.com', url: 'https://git.zx2c4.com', kind: 'cgit'},
+  {name: 'git.ti.com', url: 'https://git.ti.com/cgit', kind: 'cgit'},
+  {name: 'git.runxiyu.org', url: 'https://git.runxiyu.org', kind: 'cgit'},
+  {name: 'git.andrewyu.org', url: 'https://git.andrewyu.org', kind: 'cgit'},
+  {name: 'cgit.tilde.town', url: 'https://cgit.tilde.town', kind: 'cgit'},
+  {name: 'code.ryuslash.org', url: 'https://code.ryuslash.org', kind: 'cgit'},
+  {name: 'cgit.v2d.live', url: 'https://cgit.v2d.live', kind: 'cgit'},
+  {name: 'nebula.ed1.club/git', url: 'https://nebula.ed1.club/git', kind: 'cgit'},
   {name: 'GitHub', url: 'https://github.com', kind: 'github'},
   {name: 'GitLab.com', url: 'https://gitlab.com', kind: 'gitlab'},
   {name: 'Bitbucket.org', url: 'https://bitbucket.org', kind: 'bitbucket'},

--- a/test/models/cgit_test.rb
+++ b/test/models/cgit_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class CgitTest < ActiveSupport::TestCase
+  setup do
+    @host = Host.new(name: 'cgit', url: 'https://git.zx2c4.com', kind: 'cgit')
+    @cgit = Hosts::Cgit.new(@host)
+  end
+
+  test 'maps cgit repository page metadata' do
+    html = <<~HTML
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>wireguard-tools - Required tools for WireGuard</title>
+          <meta name="generator" content="cgit v1.3" />
+          <link rel="alternate" title="Atom feed" href="https://git.zx2c4.com/wireguard-tools/atom/?h=master" type="application/atom+xml" />
+        </head>
+      </html>
+    HTML
+
+    mapped = @cgit.map_repository_data('wireguard-tools', html)
+
+    assert_equal 'wireguard-tools', mapped[:uuid]
+    assert_equal 'wireguard-tools', mapped[:full_name]
+    assert_equal 'Required tools for WireGuard', mapped[:description]
+    assert_equal 'master', mapped[:default_branch]
+    assert_equal 'git', mapped[:scm]
+    assert_equal false, mapped[:has_issues]
+    assert_equal [], mapped[:topics]
+    assert_equal 'wireguard-tools', mapped[:metadata][:cgit_name]
+    assert_equal 'cgit v1.3', mapped[:metadata][:generator]
+  end
+
+  test 'builds cgit URLs' do
+    repository = Repository.new(host: @host, full_name: 'wireguard-tools', default_branch: 'master')
+
+    assert_equal 'https://git.zx2c4.com/wireguard-tools', @cgit.url(repository)
+    assert_equal 'https://git.zx2c4.com/wireguard-tools/plain/?h=master', @cgit.raw_url(repository)
+    assert_equal 'https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-master.tar.gz', @cgit.download_url(repository)
+  end
+end


### PR DESCRIPTION
Refs #607

## Summary

- Adds a cgit host adapter for repository metadata lookup from public cgit HTML pages.
- Maps cgit title/Atom metadata into repository fields and exposes cgit raw/archive URLs.
- Adds basic repository listing support, seed entries from the issue, and model coverage.

## Validation

- `ruby -c app/models/hosts/cgit.rb`
- `ruby -c test/models/cgit_test.rb`
- `ruby -c db/seeds.rb`
- `git diff --check`

`bundle exec ruby -Itest test/models/cgit_test.rb` is blocked locally because this checkout requires Bundler 4.0.10 from `Gemfile.lock`, which is not available in the system Ruby environment.