### PR TITLE
Add SourceHut host metadata support

### DIFF
--- a/app/models/hosts/sourcehut.rb
+++ b/app/models/hosts/sourcehut.rb
@@ -1,7 +1,110 @@
 module Hosts
   class Sourcehut < Base
+    IGNORABLE_EXCEPTIONS = [
+      Faraday::ResourceNotFound
+    ]
+
+    def self.api_missing_error_class
+      Faraday::ResourceNotFound
+    end
+
     def icon
       'sr-ht'
+    end
+
+    def url(repository)
+      "#{git_host_url}/#{sourcehut_full_name(repository.full_name)}"
+    end
+
+    def html_url(repository)
+      url(repository)
+    end
+
+    def blob_url(repository, sha = nil)
+      sha ||= repository.default_branch.presence || 'master'
+      "#{url(repository)}/tree/#{CGI.escape(sha)}/"
+    end
+
+    def raw_url(repository, sha = nil)
+      sha ||= repository.default_branch.presence || 'master'
+      "#{url(repository)}/blob/#{CGI.escape(sha)}/"
+    end
+
+    def download_url(repository, branch = nil, kind = 'branch')
+      ref = branch || repository.default_branch.presence || 'master'
+      "#{url(repository)}/archive/#{CGI.escape(ref)}.tar.gz"
+    end
+
+    def fetch_repository(id_or_name)
+      full_name = sourcehut_full_name(id_or_name)
+      resp = Faraday.get("#{git_host_url}/#{full_name}")
+      return nil unless resp.success? && resp.body.present?
+
+      map_repository_data(full_name, resp.body)
+    rescue *IGNORABLE_EXCEPTIONS
+      nil
+    rescue Faraday::Error
+      nil
+    end
+
+    def map_repository_data(full_name, html)
+      owner, name = full_name.split('/', 2)
+      title = html[/<title>\s*#{Regexp.escape(full_name)}\s*-\s*(.*?)\s*-\s*sourcehut git\s*<\/title>/m, 1]
+      description = html[/<div class="header-extension">.*?<div class="col-md-6">\s*(.*?)\s*<\/div>/m, 1]
+      default_branch = html[/<meta name="vcs:default-branch" content="([^"]+)"/, 1]
+      scm = html[/<meta name="vcs" content="([^"]+)"/, 1]
+      pushed_at = html[/<span title="([^"]+ UTC)">/, 1]
+
+      {
+        uuid: full_name,
+        full_name: full_name,
+        owner: owner.delete_prefix('~'),
+        description: cleanup_html_text(description.presence || title),
+        default_branch: default_branch.presence || 'master',
+        scm: scm.presence || 'git',
+        private: false,
+        fork: false,
+        archived: false,
+        has_issues: false,
+        pull_requests_enabled: false,
+        created_at: parse_time(pushed_at) || Time.now,
+        updated_at: parse_time(pushed_at) || Time.now,
+        pushed_at: parse_time(pushed_at),
+      }
+    end
+
+    def fetch_owner(login)
+      sourcehut_login = login.to_s.delete_prefix('~')
+      {
+        uuid: sourcehut_login,
+        login: sourcehut_login,
+        name: sourcehut_login,
+        kind: 'user'
+      }
+    end
+
+    private
+
+    def git_host_url
+      @host.url.sub(%r{https://sr\.ht/?\z}, 'https://git.sr.ht').delete_suffix('/')
+    end
+
+    def sourcehut_full_name(id_or_name)
+      parts = id_or_name.to_s.delete_prefix('/').split('/', 2)
+      owner = parts.first.to_s
+      repo = parts.second.to_s
+      owner = "~#{owner}" unless owner.start_with?('~')
+      [owner, repo].reject(&:blank?).join('/')
+    end
+
+    def cleanup_html_text(text)
+      CGI.unescapeHTML(text.to_s.gsub(/<[^>]+>/, ' ').squish)
+    end
+
+    def parse_time(value)
+      Time.parse(value) if value.present?
+    rescue ArgumentError
+      nil
     end
   end
 end

--- a/test/models/sourcehut_test.rb
+++ b/test/models/sourcehut_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class SourcehutTest < ActiveSupport::TestCase
+  setup do
+    @host = build(:sourcehut_host, url: 'https://sr.ht')
+    @sourcehut = Hosts::Sourcehut.new(@host)
+    @repository = build(:sourcehut_repository, host: @host, full_name: 'sircmpwn/git.sr.ht', default_branch: 'master')
+  end
+
+  test 'formats sourcehut repository urls on git host' do
+    assert_equal 'https://git.sr.ht/~sircmpwn/git.sr.ht', @sourcehut.url(@repository)
+    assert_equal 'https://git.sr.ht/~sircmpwn/git.sr.ht/tree/master/', @sourcehut.blob_url(@repository)
+    assert_equal 'https://git.sr.ht/~sircmpwn/git.sr.ht/blob/master/', @sourcehut.raw_url(@repository)
+    assert_equal 'https://git.sr.ht/~sircmpwn/git.sr.ht/archive/master.tar.gz', @sourcehut.download_url(@repository)
+  end
+
+  test 'maps sourcehut html repository metadata' do
+    html = <<~HTML
+      <title>
+      ~sircmpwn/git.sr.ht -
+
+      sr.ht git services -
+
+      sourcehut git
+      </title>
+      <meta name="vcs" content="git">
+      <meta name="vcs:default-branch" content="main">
+      <div class="header-extension">
+        <div class="container"><div class="row"><div class="col-md-6">
+          sr.ht git services
+        </div></div></div>
+      </div>
+      <span title="2026-04-08 09:01:21 UTC">20 days ago</span>
+    HTML
+
+    data = @sourcehut.map_repository_data('~sircmpwn/git.sr.ht', html)
+
+    assert_equal '~sircmpwn/git.sr.ht', data[:full_name]
+    assert_equal 'sircmpwn', data[:owner]
+    assert_equal 'sr.ht git services', data[:description]
+    assert_equal 'main', data[:default_branch]
+    assert_equal 'git', data[:scm]
+    assert_equal false, data[:private]
+    assert_equal false, data[:has_issues]
+    assert_equal Time.parse('2026-04-08 09:01:21 UTC'), data[:pushed_at]
+  end
+end


### PR DESCRIPTION
Refs #620

## Summary
- Expands the SourceHut host adapter beyond the existing stub with git.sr.ht URL formatting, raw/tree/archive URLs, and repository metadata fetching from public SourceHut HTML pages.
- Normalizes SourceHut owner names with the required `~` URL prefix while keeping API owner values clean.
- Adds model coverage for SourceHut URL generation and HTML metadata mapping.

## Validation
- ruby -c app/models/hosts/sourcehut.rb
- ruby -c test/models/sourcehut_test.rb
- git diff --check

`bundle exec ruby -Itest test/models/sourcehut_test.rb` remains blocked locally because this checkout requires Bundler 4.0.10 from Gemfile.lock, which is not available in the system Ruby environment.