### PR TITLE
Limit GitLab crawling to configured host org

### DIFF
--- a/app/models/hosts/gitlab.rb
+++ b/app/models/hosts/gitlab.rb
@@ -304,6 +304,12 @@ module Hosts
     end
 
     def crawl_repositories_async
+      if @host.org.present?
+        repos = load_host_org_repo_names
+        repos.each { |full_name| @host.sync_repository_async(full_name) }
+        return true
+      end
+
       last_id = REDIS.get("gitlab_last_id:#{@host.id}")
       repos = api_client.projects(per_page: 100, archived: false, id_before: last_id, simple: true)
       if repos.present? && repos.any?
@@ -327,6 +333,12 @@ module Hosts
     end
 
     def crawl_repositories_backwards
+      if @host.org.present?
+        repos = load_host_org_repos
+        repos.each { |repo| @host.sync_repository(repo["path_with_namespace"], uuid: repo["id"]) }
+        return true
+      end
+
       last_id = REDIS.get("gitlab_last_id:#{@host.id}")
       repos = api_client.projects(per_page: 100, archived: false, id_before: last_id, simple: true)
       if repos.present? && repos.any?
@@ -354,6 +366,14 @@ module Hosts
       nil
     end
 
+
+    def load_host_org_repos
+      api_client.group_projects(@host.org, per_page: 100, archived: false, simple: true, include_subgroups: true) || []
+    end
+
+    def load_host_org_repo_names
+      load_host_org_repos.map { |repo| repo["path_with_namespace"] }
+    end
 
     def load_owner_repos_names(owner)
       repos = if owner.user?

--- a/test/models/hosts/gitlab_test.rb
+++ b/test/models/hosts/gitlab_test.rb
@@ -1,6 +1,43 @@
 require "test_helper"
 
 class Hosts::GitlabTest < ActiveSupport::TestCase
+  context 'crawl_repositories' do
+    setup do
+      @host = create(:host, url: 'https://gitlab.example.com', kind: 'gitlab', org: 'public-group')
+      @gitlab_instance = Hosts::Gitlab.new(@host)
+    end
+
+    should 'limit GitLab crawling to configured host org' do
+      repos = [
+        { 'id' => 10, 'path_with_namespace' => 'public-group/project-one' },
+        { 'id' => 11, 'path_with_namespace' => 'public-group/subgroup/project-two' }
+      ]
+      api_client = mock('gitlab-api-client')
+      api_client.expects(:group_projects).with('public-group', per_page: 100, archived: false, simple: true, include_subgroups: true).returns(repos)
+      api_client.expects(:projects).never
+      @gitlab_instance.stubs(:api_client).returns(api_client)
+
+      @host.expects(:sync_repository).with('public-group/project-one', uuid: 10)
+      @host.expects(:sync_repository).with('public-group/subgroup/project-two', uuid: 11)
+
+      assert_equal true, @gitlab_instance.crawl_repositories
+    end
+
+    should 'limit async GitLab crawling to configured host org' do
+      repos = [
+        { 'id' => 10, 'path_with_namespace' => 'public-group/project-one' }
+      ]
+      api_client = mock('gitlab-api-client')
+      api_client.expects(:group_projects).with('public-group', per_page: 100, archived: false, simple: true, include_subgroups: true).returns(repos)
+      api_client.expects(:projects).never
+      @gitlab_instance.stubs(:api_client).returns(api_client)
+
+      @host.expects(:sync_repository_async).with('public-group/project-one')
+
+      assert_equal true, @gitlab_instance.crawl_repositories_async
+    end
+  end
+
   context 'recently_changed_repo_names' do
     setup do
       @host = create(:host, url: 'https://gitlab.com', kind: 'gitlab')


### PR DESCRIPTION
Refs #483

## Summary
- Uses the existing `hosts.org` configuration to scope GitLab crawling to a configured public group instead of walking the entire forge.
- Applies the group scope to both synchronous and asynchronous crawl paths.
- Adds regression coverage to verify scoped hosts call the GitLab group projects endpoint and do not fall back to forge-wide project crawling.

## Validation
- ruby -c app/models/hosts/gitlab.rb
- ruby -c test/models/hosts/gitlab_test.rb
- git diff --check

`bundle exec ruby -Itest test/models/hosts/gitlab_test.rb` remains blocked locally because this checkout requires Bundler 4.0.10 from Gemfile.lock, which is not available in the system Ruby environment.