### PR TITLE
Add owner repositories ping endpoint

### DIFF
--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -63,6 +63,11 @@ class Api::V1::OwnersController < Api::V1::ApplicationController
     render json: { message: 'pong' }
   end
 
+  def ping_repositories
+    PingOwnerRepositoriesWorker.perform_async(params[:host_id], params[:id])
+    render json: { message: 'pong' }
+  end
+
   def lookup
     scope = @host.owners
 

--- a/app/sidekiq/ping_owner_repositories_worker.rb
+++ b/app/sidekiq/ping_owner_repositories_worker.rb
@@ -1,0 +1,13 @@
+class PingOwnerRepositoriesWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :ping, lock: :until_executed, lock_expiration: 1.day.to_i
+
+  def perform(host_name, owner_login)
+    host = Host.find_by_name(host_name)
+    return unless host
+
+    owner = host.owners.find_by('lower(login) = ?', owner_login.downcase)
+    owner ||= host.sync_owner(owner_login)
+    owner.sync_repositories if owner.present? && !owner.hidden?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
           member do
             get :repositories
             get :ping
+            get :ping_repositories
           end
         end
         resources :repositories, constraints: { id: /.*/ }, defaults: { format: :json }, only: [:index, :show] do

--- a/test/controllers/api/v1/owners_controller_test.rb
+++ b/test/controllers/api/v1/owners_controller_test.rb
@@ -50,6 +50,16 @@ class ApiV1OwnersControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test 'ping owner repositories queues repository sync by owner' do
+    PingOwnerRepositoriesWorker.expects(:perform_async).with(@host.name, @owner.login)
+
+    get ping_repositories_api_v1_host_owner_path(host_id: @host.name, id: @owner.login)
+    assert_response :success
+
+    actual_response = JSON.parse(@response.body)
+    assert_equal 'pong', actual_response['message']
+  end
+
   test 'get owner names for a host' do
     # Clean up any existing owners for this test
     @host.owners.destroy_all

--- a/test/models/ping_owner_repositories_worker_test.rb
+++ b/test/models/ping_owner_repositories_worker_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class PingOwnerRepositoriesWorkerTest < ActiveSupport::TestCase
+  setup do
+    @host = create(:host, name: 'GitLab', url: 'https://gitlab.com', kind: 'gitlab')
+    @owner = @host.owners.create!(login: 'public-group', kind: :organization)
+  end
+
+  test 'syncs repositories for existing owner' do
+    Host.expects(:find_by_name).with('GitLab').returns(@host)
+    @owner.expects(:sync_repositories)
+
+    PingOwnerRepositoriesWorker.new.perform('GitLab', 'public-group')
+  end
+
+  test 'creates owner before syncing repositories when missing' do
+    new_owner = build(:owner, host: @host, login: 'new-group', kind: :organization)
+    Host.expects(:find_by_name).with('GitLab').returns(@host)
+    @host.expects(:sync_owner).with('new-group').returns(new_owner)
+    new_owner.expects(:sync_repositories)
+
+    PingOwnerRepositoriesWorker.new.perform('GitLab', 'new-group')
+  end
+end


### PR DESCRIPTION
Refs #482

## Summary
- Adds an owner-level repositories ping endpoint so callers can manually refresh repository data for an organization/group instead of pinging one repository at a time.
- Adds `PingOwnerRepositoriesWorker`, which finds or syncs the owner and then queues repository sync through the existing owner repository sync path.
- Adds controller and worker regression coverage.

## Validation
- ruby -c app/controllers/api/v1/owners_controller.rb
- ruby -c app/sidekiq/ping_owner_repositories_worker.rb
- ruby -c test/controllers/api/v1/owners_controller_test.rb
- ruby -c test/models/ping_owner_repositories_worker_test.rb
- git diff --check

`bundle exec ruby -Itest test/controllers/api/v1/owners_controller_test.rb test/models/ping_owner_repositories_worker_test.rb` remains blocked locally because this checkout requires Bundler 4.0.10 from Gemfile.lock, which is not available in the system Ruby environment.