### PR TITLE
Expose host repository stats API

### DIFF
--- a/app/controllers/api/v1/hosts_controller.rb
+++ b/app/controllers/api/v1/hosts_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::HostsController < Api::V1::ApplicationController
-  before_action :find_host_by_id, only: [:show]
+  before_action :find_host_by_id, only: [:show, :stats]
 
   def index
     scope = Host.all.order('repositories_count DESC')
@@ -9,5 +9,58 @@ class Api::V1::HostsController < Api::V1::ApplicationController
 
   def show
     fresh_when @host, public: true
+  end
+
+  def stats
+    render json: host_stats(@host)
+  end
+
+  def global_stats
+    render json: {
+      repositories_count: Repository.count,
+      hosts_count: Host.count,
+      owners_count: Owner.visible.count,
+      top_repositories: repository_stats(Repository.all),
+      top_owners: owner_stats(Owner.visible)
+    }
+  end
+
+  private
+
+  def host_stats(host)
+    repositories = host.repositories
+    owners = host.owners.visible
+
+    {
+      host: host.name,
+      repositories_count: repositories.count,
+      owners_count: owners.count,
+      top_repositories: repository_stats(repositories),
+      top_owners: owner_stats(owners)
+    }
+  end
+
+  def repository_stats(scope)
+    scope.order(Arel.sql('stargazers_count DESC NULLS LAST')).limit(10).map do |repository|
+      {
+        full_name: repository.full_name,
+        stargazers_count: repository.stargazers_count,
+        forks_count: repository.forks_count,
+        subscribers_count: repository.subscribers_count,
+        open_issues_count: repository.open_issues_count,
+        pushed_at: repository.pushed_at
+      }
+    end
+  end
+
+  def owner_stats(scope)
+    scope.order(Arel.sql('total_stars DESC NULLS LAST, repositories_count DESC NULLS LAST')).limit(10).map do |owner|
+      {
+        login: owner.login,
+        kind: owner.kind,
+        repositories_count: owner.repositories_count,
+        total_stars: owner.total_stars
+      }
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
       get 'usage/:ecosystem/:name', to: 'usage#show', as: :usage, constraints: { name: /.*/ }, defaults: { format: :json }
 
       get 'repositories/lookup', to: 'repositories#lookup', as: :repositories_lookup
+      get 'hosts/stats', to: 'hosts#global_stats', as: :hosts_stats
       resources :hosts, constraints: { id: /.*/ }, defaults: { format: :json }, only: [:index, :show] do
         resources :owners, only:[:index, :show] do
           collection do
@@ -54,6 +55,7 @@ Rails.application.routes.draw do
         
         member do
           get :repository_names, to: 'repositories#names', as: :repository_names
+          get :stats
         end
       end
 

--- a/test/controllers/api/v1/hosts_controller_test.rb
+++ b/test/controllers/api/v1/hosts_controller_test.rb
@@ -42,4 +42,30 @@ class ApiV1HostsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to api_v1_host_path(id: @host.name, foo: 'bar')
   end
 
+  test 'gets global host stats' do
+    @host.repositories.create!(full_name: 'ecosyste-ms/repos', owner: @visible_owner.login, stargazers_count: 10, forks_count: 2)
+    @visible_owner.update!(repositories_count: 1, total_stars: 10)
+
+    get api_v1_hosts_stats_path
+    assert_response :success
+
+    actual_response = JSON.parse(@response.body)
+    assert_equal 1, actual_response['hosts_count']
+    assert_equal 'ecosyste-ms/repos', actual_response['top_repositories'].first['full_name']
+    assert_equal @visible_owner.login, actual_response['top_owners'].first['login']
+  end
+
+  test 'gets stats for a host' do
+    @host.repositories.create!(full_name: 'ecosyste-ms/repos', owner: @visible_owner.login, stargazers_count: 10, forks_count: 2)
+    @visible_owner.update!(repositories_count: 1, total_stars: 10)
+
+    get stats_api_v1_host_path(id: @host.name)
+    assert_response :success
+
+    actual_response = JSON.parse(@response.body)
+    assert_equal @host.name, actual_response['host']
+    assert_equal 1, actual_response['repositories_count']
+    assert_equal 'ecosyste-ms/repos', actual_response['top_repositories'].first['full_name']
+  end
+
 end


### PR DESCRIPTION
Refs #680

## Summary
- Adds JSON stats endpoints for global repos.ecosyste.ms data and individual hosts.
- Exposes counts plus top repositories and top owners by stars/repository counts, covering the API side of the requested instance/host detail pages.
- Adds controller coverage for both global and per-host stats responses.

## Validation
- ruby -c app/controllers/api/v1/hosts_controller.rb
- ruby -c test/controllers/api/v1/hosts_controller_test.rb
- ruby -c config/routes.rb
- git diff --check

`bundle exec ruby -Itest test/controllers/api/v1/hosts_controller_test.rb` remains blocked locally because this checkout requires Bundler 4.0.10 from Gemfile.lock, which is not available in the system Ruby environment.