### PR TITLE
Add GitLab language metadata import

### DIFF
--- a/app/models/hosts/base.rb
+++ b/app/models/hosts/base.rb
@@ -32,7 +32,8 @@ module Hosts
         :status,
         :source_name,
         :template,
-        :template_full_name
+        :template_full_name,
+        :metadata
         # :allow_forking,
         # :has_projects,
         # :has_downloads,

--- a/app/models/hosts/gitlab.rb
+++ b/app/models/hosts/gitlab.rb
@@ -103,10 +103,14 @@ module Hosts
         url = "#{@endpoint}#{path}"
         Rails.logger.debug("Gitlab[get]: Fetching from URL: #{url}")
 
-        response = faraday_client.get(url)
+        response = faraday_client.get(url, options)
         JSON.parse(response.body)
       rescue JSON::ParserError
         nil
+      end
+
+      def project_languages(id_or_full_name)
+        get("/projects/#{CGI.escape(id_or_full_name.to_s)}/languages")
       end
 
       def method_missing(method, *args, &block)
@@ -280,6 +284,8 @@ module Hosts
 
       repo_hash = full_hash.slice(:id, :description, :created_at, :name, :open_issues_count, :forks_count, :default_branch, :archived, :topics)
 
+      languages = fetch_languages(project.path_with_namespace)
+
       repo_hash.merge!({
         uuid: project.id,
         full_name: project.path_with_namespace,
@@ -289,6 +295,8 @@ module Hosts
         stargazers_count: project.star_count,
         has_issues: project.try(:issues_enabled),
         has_wiki: project.try(:wiki_enabled),
+        language: primary_language(languages),
+        metadata: language_metadata(languages),
         scm: "git",
         private: project.visibility != "public",
         pull_requests_enabled: project.try(:merge_requests_enabled),
@@ -301,6 +309,28 @@ module Hosts
       repo_hash[:license] = project.license.try(:key)
       return nil if repo_hash[:full_name].nil?
       repo_hash.slice(*repository_columns)
+    end
+
+    def fetch_languages(full_name)
+      languages = if api_client.respond_to?(:project_languages)
+        api_client.project_languages(full_name)
+      else
+        api_client.get("/projects/#{CGI.escape(full_name.to_s)}/languages")
+      end
+      return {} unless languages.respond_to?(:to_h)
+      languages.to_h
+    rescue *IGNORABLE_EXCEPTIONS
+      {}
+    end
+
+    def primary_language(languages)
+      return nil if languages.blank?
+      languages.max_by { |_language, percentage| percentage.to_f }.first
+    end
+
+    def language_metadata(languages)
+      return {} if languages.blank?
+      { languages: languages }
     end
 
     def crawl_repositories_async

--- a/test/models/hosts/gitlab_test.rb
+++ b/test/models/hosts/gitlab_test.rb
@@ -93,3 +93,56 @@ class Hosts::GitlabTest < ActiveSupport::TestCase
     end
   end
 end
+class Hosts::GitlabLanguageTest < ActiveSupport::TestCase
+  context 'fetch_repository languages' do
+    setup do
+      @host = create(:host, url: 'https://gitlab.com', kind: 'gitlab')
+      @gitlab_instance = Hosts::Gitlab.new(@host)
+      @project = OpenStruct.new(
+        id: 123,
+        description: 'AMIRIS energy market model',
+        created_at: Time.zone.parse('2024-01-01'),
+        name: 'amiris',
+        open_issues_count: 4,
+        forks_count: 2,
+        default_branch: 'main',
+        archived: false,
+        topics: ['energy'],
+        namespace: OpenStruct.new(kind: 'group'),
+        visibility: 'public',
+        path_with_namespace: 'dlr-ve/esy/amiris/amiris',
+        last_activity_at: Time.zone.parse('2024-02-01'),
+        star_count: 12,
+        issues_enabled: true,
+        wiki_enabled: false,
+        vcs_type: 'git',
+        merge_requests_enabled: true,
+        avatar_url: 'https://gitlab.com/uploads/project/avatar.png',
+        forked_from_project: nil,
+        license: OpenStruct.new(key: 'apache-2.0')
+      )
+      @api_client = mock('gitlab_api_client')
+      @gitlab_instance.stubs(:api_client).returns(@api_client)
+    end
+
+    should 'populate language and language metadata from GitLab languages endpoint' do
+      @api_client.expects(:project).with('dlr-ve/esy/amiris/amiris', license: true).returns(@project)
+      @api_client.expects(:project_languages).with('dlr-ve/esy/amiris/amiris').returns({ 'Java' => 98.15, 'Python' => 1.14, 'BibTeX' => 0.71 })
+
+      repository = @gitlab_instance.fetch_repository('dlr-ve/esy/amiris/amiris')
+
+      assert_equal 'Java', repository[:language]
+      assert_equal({ 'Java' => 98.15, 'Python' => 1.14, 'BibTeX' => 0.71 }, repository[:metadata][:languages])
+    end
+
+    should 'keep language nil when GitLab languages endpoint is unavailable' do
+      @api_client.expects(:project).with('dlr-ve/esy/amiris/amiris-py', license: true).returns(@project)
+      @api_client.expects(:project_languages).with('dlr-ve/esy/amiris/amiris').raises(::Gitlab::Error::NotFound)
+
+      repository = @gitlab_instance.fetch_repository('dlr-ve/esy/amiris/amiris-py')
+
+      assert_nil repository[:language]
+      assert_equal({}, repository[:metadata])
+    end
+  end
+end


### PR DESCRIPTION
Refs #955

## Summary
- fetch GitLab project language breakdowns from the `/projects/:id/languages` API
- set the primary repository `language` from the largest percentage
- store the full GitLab language breakdown under `metadata.languages`
- add regression coverage for populated and unavailable language responses

## Validation
- `ruby -c app/models/hosts/gitlab.rb`
- `ruby -c app/models/hosts/base.rb`
- `ruby -c test/models/hosts/gitlab_test.rb`
- `git diff --check`

Full targeted test could not run locally initially because system Ruby is 2.6 while the lockfile requires Bundler 4.0.10/Ruby >= 3.2. Retrying with Homebrew Ruby 4.0.3 reached dependency install, but `bundle install` is blocked because locked `sitemap_generator (7.0.0)` is no longer available from rubygems.org.