### PR TITLE
Use two-way GitLab repository crawling

### DIFF
--- a/app/models/hosts/gitlab.rb
+++ b/app/models/hosts/gitlab.rb
@@ -304,19 +304,38 @@ module Hosts
     end
 
     def crawl_repositories_async
+      if ! crawl_repositories_backwards_async
+        crawl_repositories_forward_async
+      end
+    end
+
+    def crawl_repositories_backwards_async
       last_id = REDIS.get("gitlab_last_id:#{@host.id}")
       repos = api_client.projects(per_page: 100, archived: false, id_before: last_id, simple: true)
       if repos.present? && repos.any?
         repos.each { |repo| @host.sync_repository_async(repo["path_with_namespace"]) }
         REDIS.set("gitlab_last_id:#{@host.id}", repos.last["id"])
+        return true
+      end
+    rescue *IGNORABLE_EXCEPTIONS
+      nil
+    end
+
+    def crawl_repositories_forward_async
+      recent_id = REDIS.get("gitlab_recent_id:#{@host.id}")
+      recent_id ||= @host.repositories.maximum(:uuid)
+      repos = api_client.projects(per_page: 100, archived: false, id_after: recent_id, simple: true)
+      if repos.present? && repos.any?
+        repos.each { |repo| @host.sync_repository_async(repo["path_with_namespace"]) }
+        REDIS.set("gitlab_recent_id:#{@host.id}", repos.last["id"])
+        return true
       end
     rescue *IGNORABLE_EXCEPTIONS
       nil
     end
 
     def crawl_repositories
-      # legacy way to synchronize on ecosyste.ms
-      crawl_repositories_backwards
+      crawl_repositories_two_ways
     end
 
     def crawl_repositories_two_ways
@@ -349,6 +368,7 @@ module Hosts
       if repos.present? && repos.any?
         repos.each { |repo| @host.sync_repository(repo["path_with_namespace"], uuid: repo["id"]) }
         REDIS.set("gitlab_recent_id:#{@host.id}", repos.last["id"])
+        return true
       end
     rescue *IGNORABLE_EXCEPTIONS
       nil

--- a/test/models/hosts/gitlab_test.rb
+++ b/test/models/hosts/gitlab_test.rb
@@ -93,3 +93,39 @@ class Hosts::GitlabTest < ActiveSupport::TestCase
     end
   end
 end
+class Hosts::GitlabCrawlTest < ActiveSupport::TestCase
+  context 'crawl_repositories' do
+    setup do
+      @host = create(:host, url: 'https://gitlab.com', kind: 'gitlab')
+      @gitlab_instance = Hosts::Gitlab.new(@host)
+    end
+
+    should 'crawl forwards for newer projects after backwards crawl is exhausted' do
+      @gitlab_instance.expects(:crawl_repositories_backwards).returns(nil)
+      @gitlab_instance.expects(:crawl_repositories_forward).returns(true)
+
+      assert_equal true, @gitlab_instance.crawl_repositories
+    end
+
+    should 'not crawl forwards when backwards crawl found projects' do
+      @gitlab_instance.expects(:crawl_repositories_backwards).returns(true)
+      @gitlab_instance.expects(:crawl_repositories_forward).never
+
+      assert_equal true, @gitlab_instance.crawl_repositories
+    end
+  end
+
+  context 'crawl_repositories_async' do
+    setup do
+      @host = create(:host, url: 'https://gitlab.com', kind: 'gitlab')
+      @gitlab_instance = Hosts::Gitlab.new(@host)
+    end
+
+    should 'enqueue newer projects after backwards async crawl is exhausted' do
+      @gitlab_instance.expects(:crawl_repositories_backwards_async).returns(nil)
+      @gitlab_instance.expects(:crawl_repositories_forward_async).returns(true)
+
+      assert_equal true, @gitlab_instance.crawl_repositories_async
+    end
+  end
+end


### PR DESCRIPTION
Refs #798

## Summary
- make the default GitLab repository crawl use the existing two-way crawl strategy
- add async forward crawling with `id_after` so newly-created projects are discovered after the backwards crawl is exhausted
- return success from forward crawl paths when projects are synced/enqueued
- add regression coverage for forward fallback behavior

## Validation
- `ruby -c app/models/hosts/gitlab.rb`
- `ruby -c test/models/hosts/gitlab_test.rb`
- `git diff --check`

Full targeted test remains locally blocked: system Ruby is 2.6 and cannot use lockfile Bundler 4.0.10; Homebrew Ruby 4.0.3 reaches Bundler but dependencies are not installable because locked `sitemap_generator (7.0.0)` is no longer available from rubygems.org.