### PR TITLE
Import repository language breakdowns

### DIFF
--- a/app/models/hosts/base.rb
+++ b/app/models/hosts/base.rb
@@ -32,7 +32,8 @@ module Hosts
         :status,
         :source_name,
         :template,
-        :template_full_name
+        :template_full_name,
+        :metadata
         # :allow_forking,
         # :has_projects,
         # :has_downloads,

--- a/app/models/hosts/gitea.rb
+++ b/app/models/hosts/gitea.rb
@@ -138,18 +138,37 @@ module Hosts
         resp = api_client.get(url)
         return nil unless resp.success? && resp.body.present?
         return nil if resp.body['private']
-        map_repository_data(resp.body)
+        languages = fetch_languages(resp.body['full_name'])
+        map_repository_data(resp.body, languages: languages)
       rescue Faraday::Error
         nil
       end
     end
 
-    def map_repository_data(data)
+    def fetch_languages(full_name)
+      resp = api_client.get("api/v1/repos/#{full_name}/languages")
+      return {} unless resp.success? && resp.body.respond_to?(:to_h)
+      resp.body.to_h
+    rescue Faraday::Error
+      {}
+    end
+
+    def primary_language(languages, fallback)
+      return fallback if languages.blank?
+      languages.max_by { |_language, bytes| bytes.to_i }.first
+    end
+
+    def language_metadata(languages)
+      return {} if languages.blank?
+      { languages: languages }
+    end
+
+    def map_repository_data(data, languages: {})
       {
         uuid: data['id'],
         full_name: data['full_name']&.strip,
         owner: data['owner']&.[]('login'),
-        language: data['language'],
+        language: primary_language(languages, data['language']),
         archived: data['archived'],
         fork: data['fork'],
         description: data['description'],
@@ -171,6 +190,7 @@ module Hosts
         created_at: data['created_at'],
         updated_at: data['updated_at'],
         template: data['template'],
+        metadata: language_metadata(languages),
       }
     end
 

--- a/app/models/hosts/github.rb
+++ b/app/models/hosts/github.rb
@@ -113,10 +113,22 @@ module Hosts
       return nil if repo_response.nil?
       hash = repo_response.to_hash.with_indifferent_access
       return nil if hash[:private]
-      map_repository_data(hash)
+      languages = fetch_languages(hash[:full_name])
+      map_repository_data(hash, languages: languages)
     end
 
-    def map_repository_data(hash)
+    def fetch_languages(full_name)
+      api_client.languages(full_name).to_h
+    rescue *IGNORABLE_EXCEPTIONS, Octokit::NotFound, Octokit::RepositoryUnavailable, Octokit::UnavailableForLegalReasons
+      {}
+    end
+
+    def language_metadata(languages)
+      return {} if languages.blank?
+      { languages: languages }
+    end
+
+    def map_repository_data(hash, languages: {})
       hash[:scm] = "git"
       hash[:uuid] = hash[:id]
       hash[:license] = hash[:license][:key] if hash[:license]
@@ -124,6 +136,7 @@ module Hosts
       hash[:pull_requests_enabled] = true
       hash[:template] = hash[:is_template]
       hash[:template_full_name] = hash[:template_repository][:full_name] if hash[:template_repository]
+      hash[:metadata] = language_metadata(languages)
 
       if hash[:fork] && hash[:parent]
         hash[:source_name] = hash[:parent][:full_name]


### PR DESCRIPTION
Refs #640

## Summary
- fetch GitHub language breakdowns through the repository languages API during import
- fetch Gitea/Forgejo language breakdowns through `/api/v1/repos/:owner/:repo/languages`
- keep the primary `language` field populated from the largest detected language when breakdown data is available
- persist the full language breakdown in repository metadata

## Validation
- `ruby -c app/models/hosts/base.rb`
- `ruby -c app/models/hosts/github.rb`
- `ruby -c app/models/hosts/gitea.rb`
- `git diff --check`

Full targeted tests remain locally blocked by this repo's Ruby/Bundler dependency state: system Ruby is too old for the lockfile, and Homebrew Ruby reaches Bundler but cannot install locked `sitemap_generator (7.0.0)` from rubygems.org.