### PR TITLE
Limit GitLab syncing to public groups when configured

### DIFF
--- a/app/models/hosts/gitlab.rb
+++ b/app/models/hosts/gitlab.rb
@@ -356,6 +356,8 @@ module Hosts
 
 
     def load_owner_repos_names(owner)
+      return [] if owner.user? && ENV["SKIP_USER_REPOS"].present?
+
       repos = if owner.user?
         api_client.user_projects(owner.login, per_page: 100, archived: false, simple: true)
       else
@@ -376,6 +378,8 @@ module Hosts
         id = user["id"]
         user_response = api_client.user(id)
         return nil if user_response.nil?
+        return nil if ENV["SKIP_USER_REPOS"].present?
+
         user_hash = user_response.to_hash
         return nil if user_hash.nil?
         {


### PR DESCRIPTION
Refs #481

This makes the existing `SKIP_USER_REPOS` mode apply consistently to GitLab owner syncing:

- `fetch_owner` no longer imports GitLab user owners when `SKIP_USER_REPOS` is set
- `load_owner_repos_names` returns no repositories for user owners in that mode
- public groups continue to be synced through the existing unauthenticated group/project endpoints

Validation:
- `ruby -c app/models/hosts/gitlab.rb`
- `git diff --check`

Full test execution is still blocked locally by the repo dependency state noted in my other PRs: system Ruby is too old for the lockfile Bundler, and Homebrew Ruby cannot install locked `sitemap_generator (7.0.0)` from rubygems.org.