### PR TITLE
Add Gogs host support

### DIFF
--- a/app/models/hosts/gogs.rb
+++ b/app/models/hosts/gogs.rb
@@ -1,0 +1,14 @@
+module Hosts
+  class Gogs < Gitea
+    def icon
+      'gogs'
+    end
+
+    def api_client
+      Faraday.new(@host.url, request: {timeout: 30}) do |conn|
+        conn.request :authorization, :token, REDIS.get("gogs_token:#{@host.id}")
+        conn.response :json
+      end
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,6 +4,7 @@ default_hosts = [
   {name: 'Bitbucket.org', url: 'https://bitbucket.org', kind: 'bitbucket'},
   {name: 'SourceHut', url: 'https://sr.ht', kind: 'sourcehut'},
   {name: 'Gitea.com', url: 'https://gitea.com', kind: 'gitea'},
+  {name: 'Gogs', url: 'https://gogs.io', kind: 'gogs'},
   {name: "Codeberg.org", url: "https://codeberg.org", kind: "forgejo", org: 'Codeberg-org'},
   {name: "git.fsfe.org", url: "https://git.fsfe.org", kind: "gitea", org: 'fsfe'},
   {name: "opendev.org", url: "https://opendev.org", kind: "gitea", org: 'openstack-infra'},

--- a/test/factories/hosts.rb
+++ b/test/factories/hosts.rb
@@ -38,6 +38,12 @@ FactoryBot.define do
       kind { 'forgejo' }
     end
 
+    factory :gogs_host do
+      name { 'Gogs' }
+      url { 'https://gogs.io' }
+      kind { 'gogs' }
+    end
+
     factory :sourcehut_host do
       name { 'SourceHut' }
       url { 'https://sr.ht' }


### PR DESCRIPTION
Refs #47

Adds initial Gogs host support by reusing the Gitea-compatible API implementation.

Changes:
- Adds `Hosts::Gogs < Hosts::Gitea`
- Uses the Gogs token namespace (`gogs_token:<host_id>`) for API auth
- Adds a default Gogs host seed
- Adds a Gogs host factory for tests

Validation:
- `ruby -c app/models/hosts/gogs.rb`
- `ruby -c app/models/hosts/gitea.rb`
- `git diff --check`

Notes:
- Full Rails tests remain locally blocked by the repo dependency state already noted on related PRs.