### PR TITLE
Add SCORECARD_SYNC_ENABLED env toggle for scorecard syncing

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -659,10 +659,12 @@ class Repository < ApplicationRecord
   end
 
   def sync_scorecard
+    return unless Scorecard.sync_enabled?
     Scorecard.lookup(self)
   end
 
   def sync_scorecard_async
+    return unless Scorecard.sync_enabled?
     SyncScorecardWorker.perform_async(id)
   end
 end

--- a/app/models/scorecard.rb
+++ b/app/models/scorecard.rb
@@ -4,7 +4,12 @@ class Scorecard < ApplicationRecord
   scope :with_repository, -> { where.not(repository_id: nil) }
   scope :without_repository, -> { where(repository_id: nil) }
 
+  def self.sync_enabled?
+    ENV['SCORECARD_SYNC_ENABLED'].present?
+  end
+
   def self.sync_least_recently_synced
+    return unless sync_enabled?
     Scorecard.where(last_synced_at: nil).each(&:fetch_scorecard_async)
     Scorecard.where('last_synced_at < ?', 1.day.ago).each(&:fetch_scorecard_async)
   end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -150,28 +150,54 @@ class RepositoryTest < ActiveSupport::TestCase
   end
 
   context 'sync_scorecard method' do
-    should 'call Scorecard.lookup with self' do
+    should 'call Scorecard.lookup with self when enabled' do
+      ENV['SCORECARD_SYNC_ENABLED'] = 'true'
       host = create(:host)
       repository = create(:repository, host: host)
-      
+
       stub_request(:get, "https://api.scorecard.dev/projects/#{repository.html_url.gsub(%r{http(s)?://}, '')}")
         .to_return(status: 200, body: { score: 8.0, repo: { name: repository.full_name } }.to_json)
-      
+
       scorecard = repository.sync_scorecard
-      
+
       assert_not_nil scorecard
       assert_equal repository, scorecard.repository
       assert_equal 8.0, scorecard.score
+    ensure
+      ENV.delete('SCORECARD_SYNC_ENABLED')
+    end
+
+    should 'do nothing when not enabled' do
+      ENV.delete('SCORECARD_SYNC_ENABLED')
+      host = create(:host)
+      repository = create(:repository, host: host)
+
+      Scorecard.expects(:lookup).never
+
+      assert_nil repository.sync_scorecard
     end
   end
 
   context 'sync_scorecard_async method' do
-    should 'call SyncScorecardWorker.perform_async' do
+    should 'call SyncScorecardWorker.perform_async when enabled' do
+      ENV['SCORECARD_SYNC_ENABLED'] = 'true'
       host = create(:host)
       repository = create(:repository, host: host)
-      
+
       SyncScorecardWorker.expects(:perform_async).with(repository.id).once
-      
+
+      repository.sync_scorecard_async
+    ensure
+      ENV.delete('SCORECARD_SYNC_ENABLED')
+    end
+
+    should 'not enqueue worker when not enabled' do
+      ENV.delete('SCORECARD_SYNC_ENABLED')
+      host = create(:host)
+      repository = create(:repository, host: host)
+
+      SyncScorecardWorker.expects(:perform_async).never
+
       repository.sync_scorecard_async
     end
   end

--- a/test/models/scorecard_test.rb
+++ b/test/models/scorecard_test.rb
@@ -5,6 +5,20 @@ class ScorecardTest < ActiveSupport::TestCase
     should belong_to(:repository).optional
   end
 
+  context 'sync_enabled?' do
+    should 'be false when SCORECARD_SYNC_ENABLED is not set' do
+      ENV.delete('SCORECARD_SYNC_ENABLED')
+      refute Scorecard.sync_enabled?
+    end
+
+    should 'be true when SCORECARD_SYNC_ENABLED is set' do
+      ENV['SCORECARD_SYNC_ENABLED'] = 'true'
+      assert Scorecard.sync_enabled?
+    ensure
+      ENV.delete('SCORECARD_SYNC_ENABLED')
+    end
+  end
+
   context 'lookup method' do
     should 'create scorecard for repository' do
       host = create(:host)

--- a/test/workers/sync_scorecard_worker_test.rb
+++ b/test/workers/sync_scorecard_worker_test.rb
@@ -3,26 +3,41 @@ require 'test_helper'
 class SyncScorecardWorkerTest < ActiveSupport::TestCase
   context '#perform' do
     should 'call sync_scorecard on repository' do
+      ENV['SCORECARD_SYNC_ENABLED'] = 'true'
       host = create(:host)
       repository = create(:repository, host: host)
-      
+
       stub_request(:get, "https://api.scorecard.dev/projects/#{repository.html_url.gsub(%r{http(s)?://}, '')}")
         .to_return(status: 200, body: { score: 9.0, repo: { name: repository.full_name } }.to_json)
-      
+
       worker = SyncScorecardWorker.new
       worker.perform(repository.id)
-      
+
       repository.reload
       assert_not_nil repository.scorecard
       assert_equal 9.0, repository.scorecard.score
+    ensure
+      ENV.delete('SCORECARD_SYNC_ENABLED')
     end
 
     should 'handle non-existent repository gracefully' do
       worker = SyncScorecardWorker.new
-      
+
       assert_nothing_raised do
         worker.perform(999999)
       end
+    end
+
+    should 'not hit api when SCORECARD_SYNC_ENABLED is not set' do
+      ENV.delete('SCORECARD_SYNC_ENABLED')
+      host = create(:host)
+      repository = create(:repository, host: host)
+
+      worker = SyncScorecardWorker.new
+      worker.perform(repository.id)
+
+      repository.reload
+      assert_nil repository.scorecard
     end
   end
 end


### PR DESCRIPTION
Gate syncing to `api.scorecard.dev` behind a `SCORECARD_SYNC_ENABLED` env var so it can be turned off/on without a deploy.

`Scorecard.sync_enabled?` checks the env var and is consulted by `Repository#sync_scorecard`, `Repository#sync_scorecard_async`, and `Scorecard.sync_least_recently_synced`. Defaults to off, so `SCORECARD_SYNC_ENABLED=true` needs to be set on environments that should keep syncing.