### PR TITLE
Replace inactive repository sync with cursor sweep

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,10 @@
 {
   "cron": [
     {
+      "command": "bundle exec rake repositories:sync_inactive",
+      "schedule": "*/10 * * * *"
+    },
+    {
       "command": "bundle exec rake repositories:sync_extra_details",
       "schedule": "*/5 * * * *"
     },

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -92,8 +92,7 @@ class Repository < ApplicationRecord
     ids = where(id: (cursor + 1)..sweep_end_id).order(:id).limit(batch_size).pluck(:id)
 
     if ids.empty?
-      REDIS.del(INACTIVE_SYNC_CURSOR_KEY)
-      REDIS.del(INACTIVE_SYNC_END_ID_KEY)
+      REDIS.del(INACTIVE_SYNC_CURSOR_KEY, INACTIVE_SYNC_END_ID_KEY)
       return 0
     end
 
@@ -151,7 +150,7 @@ class Repository < ApplicationRecord
   end
 
   def inactive_sync_due?
-    !fork? && !archived? && (last_synced_at.nil? || last_synced_at < 1.week.ago)
+    !fork? && !archived? && (last_synced_at.nil? || last_synced_at <= 1.week.ago)
   end
 
   def owner_record

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,6 +1,10 @@
 class Repository < ApplicationRecord
   include EcosystemApiClient
 
+  INACTIVE_SYNC_BATCH_SIZE = 3_000
+  INACTIVE_SYNC_CURSOR_KEY = 'repositories:inactive_sync_cursor'
+  INACTIVE_SYNC_END_ID_KEY = 'repositories:inactive_sync_end_id'
+
   belongs_to :host
 
   has_many :manifests, dependent: :destroy
@@ -75,6 +79,35 @@ class Repository < ApplicationRecord
     []
   end
 
+  def self.enqueue_inactive_sync_batch(batch_size: INACTIVE_SYNC_BATCH_SIZE)
+    sweep_end_id = REDIS.get(INACTIVE_SYNC_END_ID_KEY).presence&.to_i
+    unless sweep_end_id
+      sweep_end_id = maximum(:id)
+      return 0 unless sweep_end_id
+
+      REDIS.set(INACTIVE_SYNC_END_ID_KEY, sweep_end_id)
+    end
+
+    cursor = REDIS.get(INACTIVE_SYNC_CURSOR_KEY).to_i
+    ids = where(id: (cursor + 1)..sweep_end_id).order(:id).limit(batch_size).pluck(:id)
+
+    if ids.empty?
+      REDIS.del(INACTIVE_SYNC_CURSOR_KEY)
+      REDIS.del(INACTIVE_SYNC_END_ID_KEY)
+      return 0
+    end
+
+    ids.each_slice(1_000) do |batch|
+      Sidekiq::Client.push_bulk(
+        'class' => 'SyncInactiveRepositoryWorker',
+        'queue' => 'default',
+        'args' => batch.map { |id| [id] }
+      )
+    end
+    REDIS.set(INACTIVE_SYNC_CURSOR_KEY, ids.last)
+    ids.size
+  end
+
   def self.parse_dependencies_async
     Repository.where.not(dependency_job_id: nil).limit(2000).select("id, dependencies_parsed_at").each(&:parse_dependencies_async)
     return if Sidekiq::Queue.new("dependencies").size > 2_000
@@ -115,6 +148,10 @@ class Repository < ApplicationRecord
 
   def has_scorecard?
     Scorecard.exists?(repository_id: id)
+  end
+
+  def inactive_sync_due?
+    !fork? && !archived? && (last_synced_at.nil? || last_synced_at < 1.week.ago)
   end
 
   def owner_record

--- a/app/sidekiq/sync_inactive_repository_worker.rb
+++ b/app/sidekiq/sync_inactive_repository_worker.rb
@@ -1,0 +1,9 @@
+class SyncInactiveRepositoryWorker
+  include Sidekiq::Worker
+  sidekiq_options lock: :until_executed, lock_expiration: 1.day.to_i
+
+  def perform(repository_id)
+    repository = Repository.find_by_id(repository_id)
+    repository.sync if repository&.inactive_sync_due?
+  end
+end

--- a/docs/syncing.md
+++ b/docs/syncing.md
@@ -50,7 +50,7 @@ Tags and releases are synced through several paths:
 - **During extra details sync.** When a repository's `files_changed` flag is set (because `pushed_at` changed), [`sync_extra_details`](../app/models/repository.rb#L276) calls [`download_tags`](../app/models/repository.rb#L299), which fetches tags from the host API and then releases if any tags exist.
 - **Via GHArchive.** Repositories with `ReleaseEvent` entries get their tags downloaded directly.
 - **Via timeline.** Every 20 minutes, [`repositories:download_tags`](../lib/tasks/repositories.rake#L36) calls [`Hosts::Github#sync_repos_with_tags`](../app/models/hosts/github.rb#L425), which queries timeline.ecosyste.ms for recent `ReleaseEvent` entries and downloads tags for the affected repos.
-- **Bulk catch-up.** [`Repository.download_tags_async`](../app/models/repository.rb#L71) queues up to 5000 non-fork repos ordered by `tags_last_synced_at` ascending, skipping if the tags queue already has over 5000 jobs.
+- **Bulk catch-up.** [`Repository.download_tags_async`](../app/models/repository.rb#L120) queues up to 5000 non-fork repos ordered by `tags_last_synced_at` ascending, skipping if the tags queue already has over 5000 jobs.
 
 For GitHub, tags are fetched via GraphQL ([`fetch_tags_graphql`](../app/models/hosts/github.rb#L259)) with pagination, 100 per page, ordered by commit date descending. Only new tags (not already in the database) are inserted.
 
@@ -104,10 +104,10 @@ Every 10 minutes, [`repositories:sync_inactive`](../lib/tasks/repositories.rake#
 
 ## Sync throttling
 
-- [`Repository#sync`](../app/models/repository.rb#L136) skips if synced in the last week (unless forced), scheduling a deferred re-sync 1 day after the last sync.
+- [`Repository#sync`](../app/models/repository.rb#L189) skips if synced in the last week (unless forced), scheduling a deferred re-sync 1 day after the last sync.
 - [`PingWorker`](../app/sidekiq/ping_worker.rb#L10) applies the same 1-week freshness check.
-- [`Repository.parse_dependencies_async`](../app/models/repository.rb#L61) checks the dependencies queue size and bails at 2000.
-- [`Repository.download_tags_async`](../app/models/repository.rb#L71) checks the tags queue size and bails at 5000.
+- [`Repository.parse_dependencies_async`](../app/models/repository.rb#L110) checks the dependencies queue size and bails at 2000.
+- [`Repository.download_tags_async`](../app/models/repository.rb#L120) checks the tags queue size and bails at 5000.
 - Most workers use `sidekiq_options lock: :until_executed, lock_expiration: 1.day.to_i` to prevent duplicate jobs.
 
 ## Owner syncing
@@ -126,7 +126,7 @@ Every 10 minutes, [`hosts:sync_owners`](../lib/tasks/hosts.rake#L12) syncs the 2
 When [`Host#sync_repository`](../app/models/host.rb#L82) runs:
 
 **For an existing repo:**
-1. Call [`Repository#sync`](../app/models/repository.rb#L136), which checks freshness (1 week) and then calls `update_from_host`.
+1. Call [`Repository#sync`](../app/models/repository.rb#L189), which checks freshness (1 week) and then calls `update_from_host`.
 
 **For a new repo:**
 1. Fetch repository data from the host API.

--- a/docs/syncing.md
+++ b/docs/syncing.md
@@ -98,7 +98,9 @@ Dependency parsing has its own cron entry: [`repositories:parse_missing_dependen
 
 ## Catch-up sweeps
 
-Every 10 minutes, [`repositories:sync_least_recent`](../lib/tasks/repositories.rake#L4) queues the 2000 repositories with the oldest `last_synced_at` values, skipping if the default queue already has 10,000+ jobs.
+Every 10 minutes, [`repositories:sync_inactive`](../lib/tasks/repositories.rake#L4) reads the next 3000 repository IDs from a primary-key cursor stored in Redis, skipping the run if the default queue already has 10,000+ jobs. The sweep captures the highest repository ID at the start of each pass so newly inserted rows do not keep moving its endpoint.
+
+[`SyncInactiveRepositoryWorker`](../app/sidekiq/sync_inactive_repository_worker.rb) skips forks, archived repositories, and repositories synced within the last week. This keeps the database query bounded without maintaining an index on `last_synced_at`.
 
 ## Sync throttling
 

--- a/lib/tasks/repositories.rake
+++ b/lib/tasks/repositories.rake
@@ -1,11 +1,11 @@
 require_relative '../cron_lock'
 
 namespace :repositories do
-  desc 'sync least recently synced repos'
-  task sync_least_recent: :environment do
-    CronLock.acquire("repositories:sync_least_recent", ttl: 20.minutes) do
+  desc 'sync inactive repos'
+  task sync_inactive: :environment do
+    CronLock.acquire("repositories:sync_inactive", ttl: 20.minutes) do
       if Sidekiq::Queue.new('default').size < 10_000
-        Repository.order('last_synced_at ASC').limit(2_000).select('id').each(&:sync_async)
+        Repository.enqueue_inactive_sync_batch
       end
     end
   end

--- a/test/models/repository_inactive_sync_test.rb
+++ b/test/models/repository_inactive_sync_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+class RepositoryInactiveSyncTest < ActiveSupport::TestCase
+  setup do
+    REDIS.del(Repository::INACTIVE_SYNC_CURSOR_KEY)
+    REDIS.del(Repository::INACTIVE_SYNC_END_ID_KEY)
+    SyncInactiveRepositoryWorker.clear
+  end
+
+  teardown do
+    REDIS.del(Repository::INACTIVE_SYNC_CURSOR_KEY)
+    REDIS.del(Repository::INACTIVE_SYNC_END_ID_KEY)
+    SyncInactiveRepositoryWorker.clear
+  end
+
+  test 'enqueues the next primary key batch and advances the cursor' do
+    repositories = create_list(:repository, 3).sort_by(&:id)
+
+    assert_equal 2, Repository.enqueue_inactive_sync_batch(batch_size: 2)
+    assert_equal repositories.first(2).map { |repository| [repository.id] }, queued_arguments
+    assert_equal repositories.second.id.to_s, REDIS.get(Repository::INACTIVE_SYNC_CURSOR_KEY)
+    assert_equal repositories.last.id.to_s, REDIS.get(Repository::INACTIVE_SYNC_END_ID_KEY)
+  end
+
+  test 'keeps the endpoint fixed until the sweep finishes' do
+    repositories = create_list(:repository, 2).sort_by(&:id)
+
+    Repository.enqueue_inactive_sync_batch(batch_size: 1)
+    later_repository = create(:repository)
+    SyncInactiveRepositoryWorker.clear
+
+    assert_equal 1, Repository.enqueue_inactive_sync_batch(batch_size: 10)
+    assert_equal [[repositories.last.id]], queued_arguments
+    refute_includes queued_arguments, [later_repository.id]
+  end
+
+  test 'resets the cursor after reaching the endpoint' do
+    repository = create(:repository)
+
+    Repository.enqueue_inactive_sync_batch(batch_size: 1)
+    SyncInactiveRepositoryWorker.clear
+
+    assert_equal 0, Repository.enqueue_inactive_sync_batch(batch_size: 1)
+    assert_nil REDIS.get(Repository::INACTIVE_SYNC_CURSOR_KEY)
+    assert_nil REDIS.get(Repository::INACTIVE_SYNC_END_ID_KEY)
+    assert_equal repository.id, Repository.maximum(:id)
+  end
+
+  def queued_arguments
+    SyncInactiveRepositoryWorker.jobs.map { |job| job['args'] }
+  end
+end

--- a/test/tasks/repositories_rake_test.rb
+++ b/test/tasks/repositories_rake_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+require 'rake'
+
+class RepositoriesRakeTest < ActiveSupport::TestCase
+  setup do
+    Rails.application.load_tasks unless Rake::Task.task_defined?('repositories:sync_inactive')
+  end
+
+  test 'sync_inactive queues a batch when the default queue has capacity' do
+    CronLock.expects(:acquire).with('repositories:sync_inactive', ttl: 20.minutes).yields
+    Sidekiq::Queue.any_instance.stubs(:size).returns(0)
+    Repository.expects(:enqueue_inactive_sync_batch).once
+
+    Rake::Task['repositories:sync_inactive'].execute
+  end
+
+  test 'sync_inactive skips the batch when the default queue is full' do
+    CronLock.expects(:acquire).with('repositories:sync_inactive', ttl: 20.minutes).yields
+    Sidekiq::Queue.any_instance.stubs(:size).returns(10_000)
+    Repository.expects(:enqueue_inactive_sync_batch).never
+
+    Rake::Task['repositories:sync_inactive'].execute
+  end
+end

--- a/test/workers/sync_inactive_repository_worker_test.rb
+++ b/test/workers/sync_inactive_repository_worker_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class SyncInactiveRepositoryWorkerTest < ActiveSupport::TestCase
+  context '#perform' do
+    should 'sync a repository that has never been synced' do
+      repository = create(:repository, last_synced_at: nil)
+      Repository.any_instance.expects(:sync).once
+
+      SyncInactiveRepositoryWorker.new.perform(repository.id)
+    end
+
+    should 'sync an inactive repository' do
+      repository = create(:repository, last_synced_at: 2.weeks.ago)
+      Repository.any_instance.expects(:sync).once
+
+      SyncInactiveRepositoryWorker.new.perform(repository.id)
+    end
+
+    should 'skip a recently synced repository' do
+      repository = create(:repository, last_synced_at: 1.day.ago)
+      Repository.any_instance.expects(:sync).never
+
+      SyncInactiveRepositoryWorker.new.perform(repository.id)
+    end
+
+    should 'skip a fork' do
+      repository = create(:repository, fork: true, last_synced_at: 2.weeks.ago)
+      Repository.any_instance.expects(:sync).never
+
+      SyncInactiveRepositoryWorker.new.perform(repository.id)
+    end
+
+    should 'skip an archived repository' do
+      repository = create(:repository, archived: true, last_synced_at: 2.weeks.ago)
+      Repository.any_instance.expects(:sync).never
+
+      SyncInactiveRepositoryWorker.new.perform(repository.id)
+    end
+
+    should 'handle a missing repository' do
+      assert_nothing_raised do
+        SyncInactiveRepositoryWorker.new.perform(-1)
+      end
+    end
+  end
+end

--- a/test/workers/sync_inactive_repository_worker_test.rb
+++ b/test/workers/sync_inactive_repository_worker_test.rb
@@ -16,6 +16,15 @@ class SyncInactiveRepositoryWorkerTest < ActiveSupport::TestCase
       SyncInactiveRepositoryWorker.new.perform(repository.id)
     end
 
+    should 'sync a repository last synced exactly one week ago' do
+      travel_to Time.zone.local(2026, 7, 22, 12) do
+        repository = create(:repository, last_synced_at: 1.week.ago)
+        Repository.any_instance.expects(:sync).once
+
+        SyncInactiveRepositoryWorker.new.perform(repository.id)
+      end
+    end
+
     should 'skip a recently synced repository' do
       repository = create(:repository, last_synced_at: 1.day.ago)
       Repository.any_instance.expects(:sync).never


### PR DESCRIPTION
Replace the unindexed `last_synced_at` sort with a bounded primary-key sweep that stores its cursor and endpoint in Redis. Queue a dedicated worker that skips forks, archived repositories, and repositories synced within the last week. Restore the ten-minute cron entry and document the new behavior.