### PR TITLE
GitLab token rotation rake tasks

### DIFF
--- a/lib/tasks/hosts.rake
+++ b/lib/tasks/hosts.rake
@@ -37,4 +37,59 @@ namespace :hosts do
       end
     end
   end
+
+  desc 'Print the GitLab token stored in redis for HOST'
+  task get_gitlab_token: :environment do
+    host = Host.find_by_name!(ENV['HOST'].presence || 'GitLab')
+    puts REDIS.get("gitlab_token:#{host.id}")
+  end
+
+  desc 'Store TOKEN in redis as the GitLab token for HOST'
+  task set_gitlab_token: :environment do
+    host = Host.find_by_name!(ENV['HOST'].presence || 'GitLab')
+    REDIS.set("gitlab_token:#{host.id}", ENV.fetch('TOKEN'))
+  end
+
+  desc 'Rotate a GitLab personal access token and print the new one'
+  task rotate_gitlab_token: :environment do
+    token = ENV.fetch('TOKEN')
+    url = ENV.fetch('URL', 'https://gitlab.com').chomp('/')
+    expires_at = (Date.today + Integer(ENV.fetch('DAYS', '90'))).iso8601
+
+    resp = Faraday.post("#{url}/api/v4/personal_access_tokens/self/rotate") do |req|
+      req.headers['PRIVATE-TOKEN'] = token
+      req.headers['Content-Type'] = 'application/json'
+      req.body = { expires_at: expires_at }.to_json
+    end
+
+    abort "Rotation failed: #{resp.status} #{resp.body}" unless resp.success?
+
+    json = JSON.parse(resp.body)
+    puts "New token:  #{json['token']}"
+    puts "Expires at: #{json['expires_at']}"
+    puts "Scopes:     #{Array(json['scopes']).join(', ')}"
+  end
+
+  desc 'Read the GitLab token for HOST from redis, rotate it, and write the new one back'
+  task refresh_gitlab_token: :environment do
+    host = Host.find_by_name!(ENV['HOST'].presence || 'GitLab')
+    key = "gitlab_token:#{host.id}"
+    current = REDIS.get(key)
+    abort "No token in redis at #{key}" if current.blank?
+
+    expires_at = (Date.today + Integer(ENV.fetch('DAYS', '90'))).iso8601
+
+    resp = Faraday.post("#{host.url.chomp('/')}/api/v4/personal_access_tokens/self/rotate") do |req|
+      req.headers['PRIVATE-TOKEN'] = current
+      req.headers['Content-Type'] = 'application/json'
+      req.body = { expires_at: expires_at }.to_json
+    end
+
+    abort "Rotation failed: #{resp.status} #{resp.body}" unless resp.success?
+
+    json = JSON.parse(resp.body)
+    puts "New token:  #{json['token']}"
+    puts "Expires at: #{json['expires_at']}"
+    REDIS.set(key, json['token'])
+  end
 end

--- a/test/tasks/hosts_rake_test.rb
+++ b/test/tasks/hosts_rake_test.rb
@@ -1,0 +1,115 @@
+require "test_helper"
+require "rake"
+
+class HostsRakeTest < ActiveSupport::TestCase
+  setup do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("hosts:rotate_gitlab_token")
+  end
+
+  teardown do
+    ENV.delete('TOKEN')
+    ENV.delete('URL')
+    ENV.delete('DAYS')
+    ENV.delete('HOST')
+  end
+
+  test "get_gitlab_token prints the token from redis" do
+    host = create(:gitlab_host)
+    REDIS.set("gitlab_token:#{host.id}", 'glpat-stored')
+
+    out, _ = capture_io { Rake::Task["hosts:get_gitlab_token"].execute }
+
+    assert_equal "glpat-stored\n", out
+  ensure
+    REDIS.del("gitlab_token:#{host.id}") if host
+  end
+
+  test "set_gitlab_token writes the token to redis" do
+    host = create(:gitlab_host)
+    ENV['TOKEN'] = 'glpat-fresh'
+
+    capture_io { Rake::Task["hosts:set_gitlab_token"].execute }
+
+    assert_equal 'glpat-fresh', REDIS.get("gitlab_token:#{host.id}")
+  ensure
+    REDIS.del("gitlab_token:#{host.id}") if host
+  end
+
+  test "rotate_gitlab_token posts current token and prints the new one" do
+    ENV['TOKEN'] = 'glpat-old'
+
+    stub_request(:post, "https://gitlab.com/api/v4/personal_access_tokens/self/rotate")
+      .with(
+        headers: { 'Private-Token' => 'glpat-old' },
+        body: { expires_at: (Date.today + 90).iso8601 }.to_json
+      )
+      .to_return(
+        status: 200,
+        body: { token: 'glpat-new', expires_at: '2099-01-01', scopes: ['read_api'] }.to_json
+      )
+
+    out, _ = capture_io { Rake::Task["hosts:rotate_gitlab_token"].execute }
+
+    assert_match 'glpat-new', out
+    assert_match '2099-01-01', out
+    assert_match 'read_api', out
+  end
+
+  test "rotate_gitlab_token honours URL and DAYS" do
+    ENV['TOKEN'] = 'glpat-old'
+    ENV['URL'] = 'https://gitlab.example.org'
+    ENV['DAYS'] = '30'
+
+    stub = stub_request(:post, "https://gitlab.example.org/api/v4/personal_access_tokens/self/rotate")
+      .with(body: { expires_at: (Date.today + 30).iso8601 }.to_json)
+      .to_return(status: 200, body: { token: 'x', expires_at: 'y', scopes: [] }.to_json)
+
+    capture_io { Rake::Task["hosts:rotate_gitlab_token"].execute }
+
+    assert_requested stub
+  end
+
+  test "refresh_gitlab_token rotates the redis token in place" do
+    host = create(:gitlab_host)
+    REDIS.set("gitlab_token:#{host.id}", 'glpat-old')
+
+    stub_request(:post, "https://gitlab.com/api/v4/personal_access_tokens/self/rotate")
+      .with(headers: { 'Private-Token' => 'glpat-old' })
+      .to_return(status: 200, body: { token: 'glpat-new', expires_at: '2099-01-01' }.to_json)
+
+    out, _ = capture_io { Rake::Task["hosts:refresh_gitlab_token"].execute }
+
+    assert_equal 'glpat-new', REDIS.get("gitlab_token:#{host.id}")
+    assert_match 'glpat-new', out
+    assert_match '2099-01-01', out
+  ensure
+    REDIS.del("gitlab_token:#{host.id}") if host
+  end
+
+  test "refresh_gitlab_token leaves redis untouched on failure" do
+    host = create(:gitlab_host)
+    REDIS.set("gitlab_token:#{host.id}", 'glpat-old')
+
+    stub_request(:post, "https://gitlab.com/api/v4/personal_access_tokens/self/rotate")
+      .to_return(status: 401, body: '{"message":"401 Unauthorized"}')
+
+    assert_raises(SystemExit) do
+      capture_io { Rake::Task["hosts:refresh_gitlab_token"].execute }
+    end
+
+    assert_equal 'glpat-old', REDIS.get("gitlab_token:#{host.id}")
+  ensure
+    REDIS.del("gitlab_token:#{host.id}") if host
+  end
+
+  test "rotate_gitlab_token aborts on non-success" do
+    ENV['TOKEN'] = 'glpat-old'
+
+    stub_request(:post, "https://gitlab.com/api/v4/personal_access_tokens/self/rotate")
+      .to_return(status: 401, body: '{"message":"401 Unauthorized"}')
+
+    assert_raises(SystemExit) do
+      capture_io { Rake::Task["hosts:rotate_gitlab_token"].execute }
+    end
+  end
+end


### PR DESCRIPTION
Adds rake tasks for managing GitLab host tokens without going through the rails console:

- `hosts:get_gitlab_token` prints the token stored in redis for `HOST` (default `GitLab`)
- `hosts:set_gitlab_token` writes `TOKEN` to redis for `HOST`
- `hosts:rotate_gitlab_token` calls `POST /personal_access_tokens/self/rotate` with `TOKEN` and prints the new one; runs standalone without db/redis so it can be used locally
- `hosts:refresh_gitlab_token` does the whole cycle in place on the server: read from redis, rotate against `host.url`, write the new token back

`DAYS` controls the new expiry (default 90). The old token is revoked as soon as rotation succeeds.