### PR TITLE
Detect DISCLOSURE files in metadata file checks

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -419,7 +419,8 @@ class Repository < ApplicationRecord
       copyright: file_list.find { |file| file.match(/^COPYRIGHT(?:\.(md|txt))?$/i) },
       agents: file_list.find { |file| file.match(/^(docs\/)?(.github\/)?(.gitlab\/)?AGENTS\.md$/i) },
       dco: file_list.find { |file| file.match(/^(docs\/)?(.github\/)?(.gitlab\/)?DCO(?:\.(md|txt))?$/i) },
-      cla: file_list.find { |file| file.match(/^(docs\/)?(.github\/)?(.gitlab\/)?(CLA|CONTRIBUTOR[-_ ]LICENSE[-_ ]AGREEMENT)(?:\.(md|txt))?$/i) }
+      cla: file_list.find { |file| file.match(/^(docs\/)?(.github\/)?(.gitlab\/)?(CLA|CONTRIBUTOR[-_ ]LICENSE[-_ ]AGREEMENT)(?:\.(md|txt))?$/i) },
+      disclosure: file_list.find { |file| file.match(/^DISCLOSURE(?:\.(md|txt))?$/i) }
     }
   end
 

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -611,6 +611,20 @@ class RepositoryTest < ActiveSupport::TestCase
       assert_equal 'CLA', result[:cla]
     end
 
+    should 'find disclosure files' do
+      file_list = [
+        'DISCLOSURE',
+        'DISCLOSURE.md',
+        'DISCLOSURE.txt',
+        'disclosure',
+        'other.txt'
+      ]
+      @repository.stubs(:get_file_list).returns(file_list)
+
+      result = @repository.fetch_metadata_files_list
+      assert_equal 'DISCLOSURE', result[:disclosure]
+    end
+
     should 'return hash with all keys even when no files match' do
       file_list = ['unrelated.txt', 'random.file']
       @repository.stubs(:get_file_list).returns(file_list)
@@ -643,6 +657,7 @@ class RepositoryTest < ActiveSupport::TestCase
       assert_nil result[:agents]
       assert_nil result[:dco]
       assert_nil result[:cla]
+      assert_nil result[:disclosure]
     end
 
     should 'handle mixed case and find first matching file' do


### PR DESCRIPTION
Adds `disclosure` to `Repository#fetch_metadata_files_list`, matching a root-level `DISCLOSURE` file (optionally `.md` or `.txt`).

npm now requires dual-use packages to ship a `DISCLOSURE` file at the package root: https://github.blog/changelog/2026-07-28-npm-publish-time-malware-scanning-and-dual-use-metadata/