### PR TITLE
Fix /hosts/GitHub timing out on default sort

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -14,11 +14,15 @@ class HostsController < ApplicationController
 
     scope = @host.repositories
 
-    sort = sanitize_sort(Repository.sortable_columns, default: 'id')
-    if params[:order] == 'asc'
-      scope = scope.order(sort.asc.nulls_last)
+    if params[:sort].present?
+      sort = sanitize_sort(Repository.sortable_columns, default: 'id')
+      if params[:order] == 'asc'
+        scope = scope.order(sort.asc.nulls_last)
+      else
+        scope = scope.order(sort.desc.nulls_last)
+      end
     else
-      scope = scope.order(sort.desc.nulls_last)
+      scope = scope.order(id: :desc)
     end
 
     @pagy, @repositories = pagy_countless(scope)

--- a/app/views/hosts/_tabs.html.erb
+++ b/app/views/hosts/_tabs.html.erb
@@ -20,7 +20,7 @@
       <%= t('virtual.models.topic.other') %>
     </a>
   </li>
-  <% if controller_name == 'hosts' && action_name == 'show' %>
+  <% if controller_name == 'hosts' && action_name == 'show' && @host.name != 'GitHub' %>
     <%= render 'hosts/sort' %>
   <% end %>
 </ul>

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -137,6 +137,42 @@ class HostsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to host_path(id: @host.name, sort: 'stars')
   end
 
+  test 'default sort orders by id desc without nulls last' do
+    queries = []
+    callback = ->(*, payload) { queries << payload[:sql] if payload[:sql].include?('repositories') }
+    ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') do
+      get host_path(id: @host.name)
+    end
+    assert_response :success
+    repo_query = queries.find { |q| q =~ /ORDER BY/i }
+    assert_match(/ORDER BY "repositories"\."id" DESC/i, repo_query)
+    refute_match(/NULLS LAST/i, repo_query)
+  end
+
+  test 'sort dropdown hidden for GitHub' do
+    get host_path(id: @host.name)
+    assert_response :success
+    assert_no_match(/dropdown-toggle/, response.body)
+  end
+
+  test 'sort dropdown shown for other hosts' do
+    other = Host.create(name: 'Codeberg', url: 'https://codeberg.org', kind: 'gitea')
+    get host_path(id: other.name)
+    assert_response :success
+    assert_match(/dropdown-toggle/, response.body)
+  end
+
+  test 'explicit sort param still applies nulls last' do
+    queries = []
+    callback = ->(*, payload) { queries << payload[:sql] if payload[:sql].include?('repositories') }
+    ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') do
+      get host_path(id: @host.name), params: { sort: 'stargazers_count' }
+    end
+    assert_response :success
+    repo_query = queries.find { |q| q =~ /ORDER BY/i }
+    assert_match(/stargazers_count DESC NULLS LAST/i, repo_query)
+  end
+
   test 'get a host with pagination parameters' do
     get host_path(id: @host.name), params: { page: 2, per_page: 10 }
     assert_response :success


### PR DESCRIPTION
The default `/hosts/GitHub` page was erroring because `ORDER BY id DESC NULLS LAST` doesn't match the pkey index ordering, so postgres sorted all 292M rows instead of walking the index backwards.

When no `?sort=` param is given, order by plain `id: :desc`. Explicit sort params keep `NULLS LAST` for the nullable columns.

Also hides the sort dropdown on the GitHub host page since none of those columns are indexed at that scale and clicking any of them just errors.