### PR TITLE
Preload scorecard and host on repository list APIs

### DIFF
--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -52,7 +52,7 @@ class Api::V1::OwnersController < Api::V1::ApplicationController
       scope = scope.order('last_synced_at DESC')
     end
 
-    @pagy, @repositories = pagy_countless(scope)
+    @pagy, @repositories = pagy_countless(scope.includes(:host, :scorecard))
     if stale?(@repositories, public: true)
       render 'api/v1/repositories/index'
     end

--- a/app/controllers/api/v1/repositories_controller.rb
+++ b/app/controllers/api/v1/repositories_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::RepositoriesController < Api::V1::ApplicationController
     sort_options = sort.split(',').zip(order.split(',')).to_h
     scope = scope.order(sort_options)
 
-    @pagy, @repositories = pagy_countless(scope)
+    @pagy, @repositories = pagy_countless(scope.includes(:host, :scorecard))
     fresh_when @repositories, public: true
   end
 


### PR DESCRIPTION
The `_repository.json.jbuilder` partial calls `repository.scorecard` for every row, so `/api/v1/hosts/GitHub/owners/<name>/repositories?per_page=1000` fires 1000 individual scorecard queries. Almost all return nothing since only ~930k of ~292M repos have a scorecard record.

Adds `includes(:host, :scorecard)` to `Api::V1::OwnersController#repositories` and `Api::V1::RepositoriesController#index` so scorecards load in one `IN` query. Host is included explicitly rather than relying on inverse_of propagating through the `.where` chain.