### PR TITLE
Preload scorecard on remaining repository list APIs

### DIFF
--- a/app/controllers/api/v1/dependencies_controller.rb
+++ b/app/controllers/api/v1/dependencies_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::DependenciesController < Api::V1::ApplicationController
   def index
     @usage = PackageUsage.find_by(ecosystem: params[:ecosystem], name: params[:name])
     raise ActiveRecord::RecordNotFound unless @usage
-    @scope = Dependency.where(ecosystem: @usage.ecosystem, package_name: @usage.name).includes(:manifest, {repository: :host})#.order('dependencies.id asc')
+    @scope = Dependency.where(ecosystem: @usage.ecosystem, package_name: @usage.name).includes(:manifest, {repository: [:host, :scorecard]})#.order('dependencies.id asc')
     @scope = @scope.where('dependencies.id > ?', params[:after]) if params[:after].present?
     @pagy, @dependencies = pagy_countless(@scope)
     fresh_when(@dependencies, public: true)

--- a/app/controllers/api/v1/usage_controller.rb
+++ b/app/controllers/api/v1/usage_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::UsageController < Api::V1::ApplicationController
   def dependent_repositories
     @usage = find_or_create_usage!
 
-    scope = @usage.repositories.includes(:host)
+    scope = @usage.repositories.includes(:host, :scorecard)
 
     sort = params[:sort] || 'id'
     order = params[:order] || 'asc'


### PR DESCRIPTION
`Api::V1::UsageController#dependent_repositories` and `Api::V1::DependenciesController#index` both render the `_repository` partial, which calls `repository.scorecard` per row. Both already had an `includes` for `:host` but not `:scorecard`, so each request fires one scorecard query per repository returned.

Adds `:scorecard` to the existing preloads. Follow-up to #1168.