### PR TITLE
Store owner funding in metadata instead of looking up .github repo

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -336,6 +336,7 @@ class Host < ApplicationRecord
 
     owner.assign_attributes(owner_hash)
     owner.last_synced_at = Time.now
+    owner.metadata['funding'] = owner.fetch_funding
     if owner.new_record?
       owner.repositories_count = owner.fetch_repositories_count
       owner.total_stars = owner.fetch_total_stars

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -53,10 +53,7 @@ class Owner < ApplicationRecord
   end
 
   def yaml_funding_links
-    return unless related_dot_github_repo.present? 
-    return unless related_dot_github_repo.metadata['funding'].present?
-    metadata['funding'] = related_dot_github_repo.metadata['funding']
-    return [] if metadata.blank? ||  metadata["funding"].blank?
+    return if metadata.blank? || metadata["funding"].blank?
     return [] unless metadata["funding"].is_a?(Hash)
     metadata["funding"].map do |key,v|
       next if v.blank?
@@ -115,6 +112,17 @@ class Owner < ApplicationRecord
 
   def fetch_total_stars
     repositories.sum(:stargazers_count)
+  end
+
+  def fetch_funding
+    return unless related_dot_github_repo.present?
+    related_dot_github_repo.metadata['funding']
+  end
+
+  def update_funding
+    funding = fetch_funding
+    return if metadata['funding'] == funding
+    update_column(:metadata, metadata.merge('funding' => funding))
   end
 
   def sync_repositories

--- a/lib/tasks/owners.rake
+++ b/lib/tasks/owners.rake
@@ -2,13 +2,22 @@ namespace :owners do
   desc 'backfill metadata funding from .github repos'
   task backfill_funding: :environment do
     Host.where(kind: 'github').find_each do |host|
-      count = 0
-      host.owners.find_each do |owner|
-        owner.update_funding
-        count += 1
-        puts "#{host.name}: #{count}" if (count % 10_000).zero?
+      updated = 0
+      scanned = 0
+      host.repositories
+          .where("lower(full_name) LIKE '%/.github'")
+          .where("metadata->>'funding' IS NOT NULL")
+          .each_instance do |repo|
+        scanned += 1
+        owner = host.owners.find_by('lower(login) = ?', repo.owner.downcase)
+        next unless owner
+        funding = repo.metadata['funding']
+        next if owner.metadata['funding'] == funding
+        owner.update_column(:metadata, owner.metadata.merge('funding' => funding))
+        updated += 1
+        puts "#{host.name}: #{updated} owners updated (#{scanned} .github repos scanned)" if (updated % 1000).zero?
       end
-      puts "#{host.name}: #{count} owners processed"
+      puts "#{host.name}: #{updated} owners updated (#{scanned} .github repos with funding)"
     end
   end
 end

--- a/lib/tasks/owners.rake
+++ b/lib/tasks/owners.rake
@@ -1,0 +1,14 @@
+namespace :owners do
+  desc 'backfill metadata funding from .github repos'
+  task backfill_funding: :environment do
+    Host.where(kind: 'github').find_each do |host|
+      count = 0
+      host.owners.find_each do |owner|
+        owner.update_funding
+        count += 1
+        puts "#{host.name}: #{count}" if (count % 10_000).zero?
+      end
+      puts "#{host.name}: #{count} owners processed"
+    end
+  end
+end

--- a/test/models/owner_test.rb
+++ b/test/models/owner_test.rb
@@ -26,6 +26,57 @@ class OwnerTest < ActiveSupport::TestCase
     end
   end
 
+  context 'funding' do
+    setup do
+      @host = FactoryBot.create(:github_host)
+      @owner = FactoryBot.create(:owner, host: @host, login: 'acme', metadata: {})
+    end
+
+    should 'return sponsors link when has_sponsors_listing and no funding metadata' do
+      @owner.metadata['has_sponsors_listing'] = true
+      assert_equal ['https://github.com/sponsors/acme'], @owner.funding_links
+    end
+
+    should 'return empty when no sponsors listing and no funding metadata' do
+      assert_equal [], @owner.funding_links
+    end
+
+    should 'map funding metadata to urls without querying repositories' do
+      @owner.metadata['funding'] = { 'github' => ['acme'], 'open_collective' => 'acme' }
+      queries = 0
+      callback = ->(*, payload) { queries += 1 unless payload[:name] == 'SCHEMA' }
+      ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') do
+        links = @owner.funding_links
+        assert_includes links, 'https://github.com/sponsors/acme'
+        assert_includes links, 'https://opencollective.com/acme'
+      end
+      assert_equal 0, queries
+    end
+
+    should 'fetch_funding reads from related .github repo' do
+      FactoryBot.create(:repository, host: @host, full_name: 'acme/.github', owner: 'acme',
+                        metadata: { 'funding' => { 'github' => ['acme'] } })
+      assert_equal({ 'github' => ['acme'] }, @owner.fetch_funding)
+    end
+
+    should 'fetch_funding returns nil when no .github repo' do
+      assert_nil @owner.fetch_funding
+    end
+
+    should 'update_funding persists funding into metadata' do
+      FactoryBot.create(:repository, host: @host, full_name: 'acme/.github', owner: 'acme',
+                        metadata: { 'funding' => { 'ko_fi' => 'acme' } })
+      @owner.update_funding
+      assert_equal({ 'ko_fi' => 'acme' }, @owner.reload.metadata['funding'])
+    end
+
+    should 'update_funding is a no-op when funding unchanged' do
+      @owner.update_column(:metadata, { 'funding' => nil })
+      @owner.expects(:update_column).never
+      @owner.update_funding
+    end
+  end
+
   context 'sync methods' do
     setup do
       @host = FactoryBot.create(:github_host)

--- a/test/tasks/owners_rake_test.rb
+++ b/test/tasks/owners_rake_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+require 'rake'
+
+class OwnersRakeTest < ActiveSupport::TestCase
+  setup do
+    Rails.application.load_tasks unless Rake::Task.task_defined?('owners:backfill_funding')
+    @host = FactoryBot.create(:github_host)
+  end
+
+  test 'backfill_funding copies .github repo funding into owner metadata' do
+    owner = FactoryBot.create(:owner, host: @host, login: 'acme', metadata: { 'has_sponsors_listing' => true })
+    FactoryBot.create(:repository, host: @host, full_name: 'acme/.github', owner: 'acme',
+                      metadata: { 'funding' => { 'github' => ['acme'] } })
+
+    capture_io { Rake::Task['owners:backfill_funding'].execute }
+
+    owner.reload
+    assert_equal({ 'github' => ['acme'] }, owner.metadata['funding'])
+    assert_equal true, owner.metadata['has_sponsors_listing']
+  end
+
+  test 'backfill_funding leaves owners without a .github repo untouched' do
+    owner = FactoryBot.create(:owner, host: @host, login: 'nofunding', metadata: { 'has_sponsors_listing' => false })
+
+    capture_io { Rake::Task['owners:backfill_funding'].execute }
+
+    assert_nil owner.reload.metadata['funding']
+  end
+end


### PR DESCRIPTION
`Owner#funding_links` loaded the owner's `.github` repository on every call to read its `metadata['funding']`, so rendering `/api/v1/hosts/GitHub/owners?per_page=1000` fired 1000 `find_by` queries against the repositories table.

Copy the `.github` repo's funding hash into `owner.metadata['funding']` during `Host#sync_owner`, and change `Owner#funding_links` to read only from the owner's own metadata. `related_dot_github_repo` is now only called at sync time.

Adds `rake owners:backfill_funding` to populate existing owners without waiting for their next weekly sync. With 36M GitHub owners, iterating owners would take hours of point lookups; instead the task does a single streamed seq scan of repositories for `.github` repos that already have `metadata['funding']` set and updates the matching owner for each.