### PR TITLE
Record GitHub release immutability

### DIFF
--- a/app/models/hosts/github.rb
+++ b/app/models/hosts/github.rb
@@ -190,27 +190,43 @@ module Hosts
     def download_releases(repository)
       releases = fetch_releases(repository)
       return unless releases.present?
-      
+
       # Get existing release UUIDs in one query
-      existing_uuids = repository.releases.pluck(:uuid).to_set
-      
+      release_uuids = releases.map { |release| release[:uuid].to_s }
+      existing_releases = repository.releases.where(uuid: release_uuids).pluck(:uuid, :immutable).to_h
+
+      # Refresh immutability when the stored value differs from GitHub
+      changed_releases = releases.select do |release|
+        uuid = release[:uuid].to_s
+        existing_releases.key?(uuid) && existing_releases[uuid] != release[:immutable]
+      end
+      now = Time.current
+      changed_releases.group_by { |release| release[:immutable] }.each do |immutable, grouped_releases|
+        uuids = grouped_releases.map { |release| release[:uuid].to_s }
+        repository.releases.where(uuid: uuids).update_all(
+          immutable: immutable,
+          last_synced_at: now,
+          updated_at: now
+        )
+      end
+
       # Filter out existing releases
-      new_releases = releases.reject { |release| existing_uuids.include?(release[:uuid].to_s) }
-      
+      new_releases = releases.reject { |release| existing_releases.key?(release[:uuid].to_s) }
+
       if new_releases.any?
         # Prepare records for bulk insert
         release_records = new_releases.map do |release|
           release.merge(
             repository_id: repository.id,
-            created_at: Time.current,
-            updated_at: Time.current
+            created_at: now,
+            updated_at: now
           )
         end
-        
+
         # Bulk insert new releases only
         Release.insert_all(release_records)
       end
-      
+
       nil
     rescue *IGNORABLE_EXCEPTIONS, Octokit::NotFound, Octokit::RepositoryUnavailable, Octokit::UnavailableForLegalReasons
       nil
@@ -239,6 +255,7 @@ module Hosts
           body: release.body.try(:delete, "\u0000"),
           draft: release.draft,
           prerelease: release.prerelease,
+          immutable: release.immutable,
           created_at: release.created_at,
           published_at: release.published_at,
           author: release.author.try(:login),

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -18,8 +18,8 @@ class Release < ApplicationRecord
       repository = host.find_repository(name)
       if repository
         needs_backfill = false
-        repository.releases.select(:immutable).each_row(block_size: block_size) do |row|
-          needs_backfill = true if row['immutable'].nil?
+        repository.releases.select(:immutable).each_row(block_size: block_size, until: true) do |row|
+          needs_backfill = row['immutable'].nil?
         end
 
         if needs_backfill

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -1,44 +1,43 @@
 class Release < ApplicationRecord
   belongs_to :repository
 
-  def self.backfill_immutability(batch_size: 10_000, after_id: 0)
-    raise ArgumentError, 'batch_size must be greater than zero' unless batch_size.positive?
+  def self.backfill_immutability(repository_names:, block_size: 1_000, after_name: nil)
+    raise ArgumentError, 'block_size must be greater than zero' unless block_size.positive?
 
-    scanned = 0
+    host = Host.find_by_name('GitHub')
+    return [0, 0, 0, after_name] unless host
+
+    names = repository_names.compact.uniq.sort_by(&:downcase)
+    names = names.drop_while { |name| name.downcase <= after_name.downcase } if after_name.present?
+    processed = 0
     repositories_synced = 0
-    cursor = after_id
+    repositories_missing = 0
+    last_name = after_name
 
-    loop do
-      rows = []
-      where('id > ?', cursor)
-        .order('releases.id')
-        .limit(batch_size)
-        .select('releases.id', 'releases.repository_id', 'releases.immutable')
-        .each_row(block_size: [batch_size, 1_000].min) do |row|
-          rows << [row['id'].to_i, row['repository_id'].to_i, row['immutable']]
+    names.each do |name|
+      repository = host.find_repository(name)
+      if repository
+        needs_backfill = false
+        repository.releases.select(:immutable).each_row(block_size: block_size) do |row|
+          needs_backfill = true if row['immutable'].nil?
         end
 
-      break if rows.empty?
-
-      cursor = rows.last.first
-      repository_ids = rows.filter_map do |_id, repository_id, immutable|
-        repository_id if immutable.nil?
-      end.uniq
-      repositories = Repository.includes(:host).where(id: repository_ids).index_by(&:id)
-
-      repository_ids.each do |repository_id|
-        repository = repositories[repository_id]
-        next unless repository&.host&.kind == 'github'
-
-        repository.download_releases
-        repositories_synced += 1
+        if needs_backfill
+          repository.download_releases
+          repositories_synced += 1
+        end
+      else
+        repositories_missing += 1
       end
 
-      scanned += rows.size
-      yield(scanned, repositories_synced, cursor) if block_given?
+      processed += 1
+      last_name = name
+      if block_given? && (processed == 1 || (processed % 100).zero?)
+        yield(processed, repositories_synced, repositories_missing, last_name)
+      end
     end
 
-    [scanned, repositories_synced, cursor]
+    [processed, repositories_synced, repositories_missing, last_name]
   end
 
   def to_s

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -1,6 +1,46 @@
 class Release < ApplicationRecord
   belongs_to :repository
 
+  def self.backfill_immutability(batch_size: 10_000, after_id: 0)
+    raise ArgumentError, 'batch_size must be greater than zero' unless batch_size.positive?
+
+    scanned = 0
+    repositories_synced = 0
+    cursor = after_id
+
+    loop do
+      rows = []
+      where('id > ?', cursor)
+        .order('releases.id')
+        .limit(batch_size)
+        .select('releases.id', 'releases.repository_id', 'releases.immutable')
+        .each_row(block_size: [batch_size, 1_000].min) do |row|
+          rows << [row['id'].to_i, row['repository_id'].to_i, row['immutable']]
+        end
+
+      break if rows.empty?
+
+      cursor = rows.last.first
+      repository_ids = rows.filter_map do |_id, repository_id, immutable|
+        repository_id if immutable.nil?
+      end.uniq
+      repositories = Repository.includes(:host).where(id: repository_ids).index_by(&:id)
+
+      repository_ids.each do |repository_id|
+        repository = repositories[repository_id]
+        next unless repository&.host&.kind == 'github'
+
+        repository.download_releases
+        repositories_synced += 1
+      end
+
+      scanned += rows.size
+      yield(scanned, repositories_synced, cursor) if block_given?
+    end
+
+    [scanned, repositories_synced, cursor]
+  end
+
   def to_s
     name
   end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -559,32 +559,8 @@ class Repository < ApplicationRecord
   end
 
   def self.parse_dependencies_for_github_actions_tags
-    conn = ecosystem_connection(PACKAGES_DOMAIN)
-
-    repo_names = Set.new
-
-    response = conn.get("/api/v1/registries/github%20actions/packages?sort=updated_at&order=desc")
-    return nil unless response.success?
-
-    links = parse_link_header(response.headers)
-
-    while links["next"].present?
-      json = response.body.is_a?(String) ? Oj.load(response.body) : response.body
-
-      json.each do |package|
-        repo_names << package["name"]
-      end
-
-      response = conn.get(links["next"].gsub(PACKAGES_DOMAIN, ''))
-      return nil unless response.success?
-      links = parse_link_header(response.headers)
-    end
-
-    # Process the final page
-    json = response.body.is_a?(String) ? Oj.load(response.body) : response.body
-    json.each do |package|
-      repo_names << package["name"]
-    end
+    repo_names = github_actions_package_names
+    return nil unless repo_names
 
     host = Host.find_by_name("GitHub")
 
@@ -599,6 +575,27 @@ class Repository < ApplicationRecord
         tag.parse_dependencies_async if tag.dependencies_parsed_at.nil?
       end
     end
+  end
+
+  def self.github_actions_package_names
+    conn = ecosystem_connection(PACKAGES_DOMAIN)
+    path = "/api/v1/registries/github%20actions/package_names?per_page=10000&sort=name&order=asc"
+    repo_names = Set.new
+
+    loop do
+      response = conn.get(path)
+      return nil unless response.success?
+
+      names = response.body.is_a?(String) ? Oj.load(response.body) : response.body
+      repo_names.merge(names)
+
+      next_path = parse_link_header(response.headers)["next"]
+      break unless next_path.present?
+
+      path = next_path.gsub(PACKAGES_DOMAIN, '')
+    end
+
+    repo_names
   end
 
   def self.parse_link_header(headers)

--- a/app/views/api/v1/releases/_release.json.jbuilder
+++ b/app/views/api/v1/releases/_release.json.jbuilder
@@ -1,3 +1,3 @@
-json.extract! release, :name, :uuid, :tag_name, :target_commitish, :body, :draft, :prerelease, :published_at, :created_at, :author, :assets, :last_synced_at, :html_url
+json.extract! release, :name, :uuid, :tag_name, :target_commitish, :body, :draft, :prerelease, :immutable, :published_at, :created_at, :author, :assets, :last_synced_at, :html_url
 json.release_url api_v1_host_repository_release_url(release.repository.host, release.repository, release)
 json.tag_url api_v1_host_repository_tag_url(release.repository.host, release.repository, release)

--- a/db/migrate/20260805110000_add_immutable_to_releases.rb
+++ b/db/migrate/20260805110000_add_immutable_to_releases.rb
@@ -1,0 +1,5 @@
+class AddImmutableToReleases < ActiveRecord::Migration[8.1]
+  def change
+    add_column :releases, :immutable, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_12_160000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_05_110000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -142,6 +142,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_12_160000) do
     t.text "body"
     t.datetime "created_at", null: false
     t.boolean "draft"
+    t.boolean "immutable"
     t.datetime "last_synced_at"
     t.string "name"
     t.boolean "prerelease"

--- a/lib/tasks/releases.rake
+++ b/lib/tasks/releases.rake
@@ -1,0 +1,16 @@
+namespace :releases do
+  desc 'Backfill GitHub release immutability'
+  task :backfill_immutability, [:batch_size, :after_id] => :environment do |_task, args|
+    batch_size = (args[:batch_size] || 10_000).to_i
+    after_id = (args[:after_id] || 0).to_i
+
+    puts "Scanning releases after id #{after_id} in batches of #{batch_size}"
+    scanned, repositories_synced, last_id = Release.backfill_immutability(
+      batch_size: batch_size,
+      after_id: after_id
+    ) do |current_scanned, current_repositories_synced, current_id|
+      puts "Scanned #{current_scanned} releases, synced #{current_repositories_synced} repositories, last id #{current_id}"
+    end
+    puts "Done: scanned #{scanned} releases and synced #{repositories_synced} repositories; last id #{last_id}"
+  end
+end

--- a/lib/tasks/releases.rake
+++ b/lib/tasks/releases.rake
@@ -1,16 +1,18 @@
 namespace :releases do
   desc 'Backfill GitHub release immutability'
-  task :backfill_immutability, [:batch_size, :after_id] => :environment do |_task, args|
-    batch_size = (args[:batch_size] || 10_000).to_i
-    after_id = (args[:after_id] || 0).to_i
+  task :backfill_immutability, [:block_size, :after_name] => :environment do |_task, args|
+    block_size = (args[:block_size] || 1_000).to_i
+    repository_names = Repository.github_actions_package_names
+    abort 'Unable to load GitHub Actions package names' unless repository_names
 
-    puts "Scanning releases after id #{after_id} in batches of #{batch_size}"
-    scanned, repositories_synced, last_id = Release.backfill_immutability(
-      batch_size: batch_size,
-      after_id: after_id
-    ) do |current_scanned, current_repositories_synced, current_id|
-      puts "Scanned #{current_scanned} releases, synced #{current_repositories_synced} repositories, last id #{current_id}"
+    puts "Loaded #{repository_names.size} GitHub Actions package names"
+    processed, repositories_synced, repositories_missing, last_name = Release.backfill_immutability(
+      repository_names: repository_names,
+      block_size: block_size,
+      after_name: args[:after_name]
+    ) do |current_processed, current_synced, current_missing, current_name|
+      puts "Processed #{current_processed} names, synced #{current_synced} repositories, missing #{current_missing}, last name #{current_name}"
     end
-    puts "Done: scanned #{scanned} releases and synced #{repositories_synced} repositories; last id #{last_id}"
+    puts "Done: processed #{processed} names, synced #{repositories_synced} repositories, missing #{repositories_missing}; last name #{last_name}"
   end
 end

--- a/test/controllers/api/v1/releases_controller_test.rb
+++ b/test/controllers/api/v1/releases_controller_test.rb
@@ -8,12 +8,14 @@ class Api::V1::ReleasesControllerTest < ActionDispatch::IntegrationTest
     @release_v1 = create(:release, 
       repository: @repository,
       tag_name: 'v1.0.0',
+      immutable: false,
       published_at: 2.days.ago
     )
     
     @release_v2 = create(:release,
       repository: @repository, 
       tag_name: 'v2.0.0',
+      immutable: true,
       published_at: 1.day.ago
     )
   end
@@ -74,6 +76,8 @@ class Api::V1::ReleasesControllerTest < ActionDispatch::IntegrationTest
     assert release.key?('body')
     assert release.key?('draft')
     assert release.key?('prerelease')
+    assert release.key?('immutable')
+    assert release['immutable']
   end
 
   test "should include release attributes in show" do
@@ -89,6 +93,8 @@ class Api::V1::ReleasesControllerTest < ActionDispatch::IntegrationTest
     assert data.key?('body')
     assert data.key?('draft')
     assert data.key?('prerelease')
+    assert data.key?('immutable')
+    assert_not data['immutable']
   end
 
   test "should set proper cache headers for index" do

--- a/test/factories/releases.rb
+++ b/test/factories/releases.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     target_commitish { 'main' }
     draft { false }
     prerelease { false }
+    immutable { false }
     published_at { rand(1..30).days.ago }
     author { 'octocat' }
     assets { [] }

--- a/test/models/hosts/github_test.rb
+++ b/test/models/hosts/github_test.rb
@@ -17,6 +17,7 @@ class Hosts::GithubTest < ActiveSupport::TestCase
         body: 'First release',
         draft: false,
         prerelease: false,
+        immutable: true,
         created_at: 1.day.ago,
         published_at: 1.day.ago,
         author: OpenStruct.new(login: 'testuser'),
@@ -37,17 +38,18 @@ class Hosts::GithubTest < ActiveSupport::TestCase
       assert_equal 1, result.length
       assert_equal 1, result.first[:uuid]
       assert_equal 'v1.0.0', result.first[:tag_name]
+      assert result.first[:immutable]
     end
 
     should 'stop after max_pages' do
       release1 = OpenStruct.new(
         id: 1, tag_name: 'v1.0', target_commitish: 'main', name: 'r', body: 'b',
-        draft: false, prerelease: false, created_at: Time.now, published_at: Time.now,
+        draft: false, prerelease: false, immutable: false, created_at: Time.now, published_at: Time.now,
         author: OpenStruct.new(login: 'u'), assets: []
       )
       release2 = OpenStruct.new(
         id: 2, tag_name: 'v2.0', target_commitish: 'main', name: 'r2', body: 'b2',
-        draft: false, prerelease: false, created_at: Time.now, published_at: Time.now,
+        draft: false, prerelease: false, immutable: true, created_at: Time.now, published_at: Time.now,
         author: OpenStruct.new(login: 'u'), assets: []
       )
 
@@ -82,6 +84,42 @@ class Hosts::GithubTest < ActiveSupport::TestCase
       result = @github.fetch_releases(@repository)
 
       assert_equal [], result
+    end
+  end
+
+  context 'download_releases' do
+    should 'store immutability for new releases and refresh existing releases' do
+      existing_release = create(
+        :release,
+        repository: @repository,
+        uuid: '1',
+        tag_name: 'v1.0.0',
+        immutable: false,
+        last_synced_at: 2.days.ago
+      )
+      unchanged_updated_at = 2.days.ago.change(usec: 0)
+      unchanged_release = create(
+        :release,
+        repository: @repository,
+        uuid: '2',
+        tag_name: 'v2.0.0',
+        immutable: false,
+        updated_at: unchanged_updated_at
+      )
+
+      @github.stubs(:fetch_releases).with(@repository).returns([
+        { uuid: 1, tag_name: 'v1.0.0', immutable: true, last_synced_at: Time.current },
+        { uuid: 2, tag_name: 'v2.0.0', immutable: false, last_synced_at: Time.current },
+        { uuid: 3, tag_name: 'v3.0.0', immutable: false, last_synced_at: Time.current }
+      ])
+
+      @github.download_releases(@repository)
+
+      assert_equal 3, @repository.releases.count
+      assert existing_release.reload.immutable
+      assert_not @repository.releases.find_by!(uuid: '3').immutable
+      assert_operator existing_release.last_synced_at, :>, 2.days.ago
+      assert_equal unchanged_updated_at, unchanged_release.reload.updated_at
     end
   end
 

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -43,17 +43,20 @@ class ReleaseTest < ActiveSupport::TestCase
 
   test 'backfill_immutability syncs GitHub repositories in bounded cursor batches' do
     github_host = create(:github_host)
-    first_repository = create(:repository, host: github_host)
-    second_repository = create(:repository, host: github_host)
+    first_repository = create(:repository, host: github_host, full_name: 'actions/checkout')
+    second_repository = create(:repository, host: github_host, full_name: 'actions/setup-node')
     create(:release, repository: first_repository, immutable: nil)
     create(:release, repository: second_repository, immutable: nil)
 
-    gitlab_repository = create(:gitlab_repository)
-    create(:release, repository: gitlab_repository, immutable: nil)
-
-    known_repository = create(:repository, host: github_host)
+    known_repository = create(:repository, host: github_host, full_name: 'actions/known')
     create(:release, repository: known_repository, immutable: false)
 
+    repository_names = [
+      first_repository.full_name,
+      second_repository.full_name.upcase,
+      known_repository.full_name,
+      'missing/action'
+    ]
     expected_repository_ids = [first_repository.id, second_repository.id]
     open_transactions = []
     Host.any_instance.expects(:download_releases).twice.with do |repository|
@@ -62,23 +65,25 @@ class ReleaseTest < ActiveSupport::TestCase
       true
     end
     transaction_count = Release.connection.open_transactions
-    release_count = Release.count
-    last_release_id = Release.maximum(:id)
 
-    scanned, repositories_synced, last_id = Release.backfill_immutability(batch_size: 1)
+    processed, repositories_synced, repositories_missing, last_name = Release.backfill_immutability(
+      repository_names: repository_names,
+      block_size: 1
+    )
 
     assert_empty expected_repository_ids
     assert_equal [transaction_count, transaction_count], open_transactions
-    assert_equal release_count, scanned
+    assert_equal 4, processed
     assert_equal 2, repositories_synced
-    assert_equal last_release_id, last_id
+    assert_equal 1, repositories_missing
+    assert_equal repository_names.sort_by(&:downcase).last, last_name
   end
 
   test 'backfill_immutability rejects an empty batch' do
     error = assert_raises(ArgumentError) do
-      Release.backfill_immutability(batch_size: 0)
+      Release.backfill_immutability(repository_names: [], block_size: 0)
     end
 
-    assert_equal 'batch_size must be greater than zero', error.message
+    assert_equal 'block_size must be greater than zero', error.message
   end
 end

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -40,4 +40,45 @@ class ReleaseTest < ActiveSupport::TestCase
 
     assert_equal 1, (release1 <=> release2)
   end
+
+  test 'backfill_immutability syncs GitHub repositories in bounded cursor batches' do
+    github_host = create(:github_host)
+    first_repository = create(:repository, host: github_host)
+    second_repository = create(:repository, host: github_host)
+    create(:release, repository: first_repository, immutable: nil)
+    create(:release, repository: second_repository, immutable: nil)
+
+    gitlab_repository = create(:gitlab_repository)
+    create(:release, repository: gitlab_repository, immutable: nil)
+
+    known_repository = create(:repository, host: github_host)
+    create(:release, repository: known_repository, immutable: false)
+
+    expected_repository_ids = [first_repository.id, second_repository.id]
+    open_transactions = []
+    Host.any_instance.expects(:download_releases).twice.with do |repository|
+      expected_repository_ids.delete(repository.id)
+      open_transactions << Release.connection.open_transactions
+      true
+    end
+    transaction_count = Release.connection.open_transactions
+    release_count = Release.count
+    last_release_id = Release.maximum(:id)
+
+    scanned, repositories_synced, last_id = Release.backfill_immutability(batch_size: 1)
+
+    assert_empty expected_repository_ids
+    assert_equal [transaction_count, transaction_count], open_transactions
+    assert_equal release_count, scanned
+    assert_equal 2, repositories_synced
+    assert_equal last_release_id, last_id
+  end
+
+  test 'backfill_immutability rejects an empty batch' do
+    error = assert_raises(ArgumentError) do
+      Release.backfill_immutability(batch_size: 0)
+    end
+
+    assert_equal 'batch_size must be greater than zero', error.message
+  end
 end

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -86,4 +86,19 @@ class ReleaseTest < ActiveSupport::TestCase
 
     assert_equal 'block_size must be greater than zero', error.message
   end
+
+  test 'backfill_immutability stops the release cursor after finding an unknown value' do
+    github_host = mock('github_host')
+    repository = mock('repository')
+    releases = mock('releases')
+    cursor = mock('cursor')
+    Host.expects(:find_by_name).with('GitHub').returns(github_host)
+    github_host.expects(:find_repository).with('actions/checkout').returns(repository)
+    repository.expects(:releases).returns(releases)
+    releases.expects(:select).with(:immutable).returns(cursor)
+    cursor.expects(:each_row).with(block_size: 1_000, until: true).yields({ 'immutable' => nil })
+    repository.expects(:download_releases)
+
+    Release.backfill_immutability(repository_names: ['actions/checkout'])
+  end
 end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -1034,40 +1034,14 @@ class RepositoryTest < ActiveSupport::TestCase
       @repo = FactoryBot.create(:repository, host: @host, full_name: 'actions/checkout', owner: 'actions')
     end
 
-    should 'parse JSON response body correctly and collect repo names' do
-      # Mock the API responses
-      first_response_body = [
-        { "name" => "actions/checkout" },
-        { "name" => "actions/setup-node" }
-      ].to_json
-
-      second_response_body = [
-        { "name" => "actions/upload-artifact" }
-      ].to_json
-
-      # Mock the connection and responses
-      first_response = mock('first_response')
-      first_response.stubs(:success?).returns(true)
-      first_response.stubs(:body).returns(first_response_body)
-      first_response.stubs(:headers).returns({
-        "Link" => '</api/v1/registries/github%20actions/packages?page=2>; rel="next"'
-      })
-
-      second_response = mock('second_response')
-      second_response.stubs(:success?).returns(true)
-      second_response.stubs(:body).returns(second_response_body)
-      second_response.stubs(:headers).returns({})
-
-      conn = mock('connection')
-      conn.expects(:get).with("/api/v1/registries/github%20actions/packages?sort=updated_at&order=desc").returns(first_response)
-      conn.expects(:get).with('/api/v1/registries/github%20actions/packages?page=2').returns(second_response)
-
-      Repository.stubs(:ecosystem_connection).returns(conn)
-
-      # Mock Host.find_by_name to return our test host
+    should 'process GitHub Actions package names' do
+      Repository.stubs(:github_actions_package_names).returns(Set.new([
+        'actions/checkout',
+        'actions/setup-node',
+        'actions/upload-artifact'
+      ]))
       Host.stubs(:find_by_name).with("GitHub").returns(@host)
 
-      # Mock host.find_repository to return nil so it triggers sync_repository_async
       @host.expects(:find_repository).with("actions/checkout").returns(nil)
       @host.expects(:sync_repository_async).with("actions/checkout").once
       @host.expects(:find_repository).with("actions/setup-node").returns(nil)
@@ -1075,55 +1049,51 @@ class RepositoryTest < ActiveSupport::TestCase
       @host.expects(:find_repository).with("actions/upload-artifact").returns(nil)
       @host.expects(:sync_repository_async).with("actions/upload-artifact").once
 
-      # Call the method
       Repository.parse_dependencies_for_github_actions_tags
     end
 
-    should 'handle string response body by parsing with Oj.load' do
-      # This test verifies the fix for the NoMethodError bug
-      response_body = [
-        { "name" => "actions/checkout" }
-      ].to_json
-
-      response = mock('response')
-      response.stubs(:success?).returns(true)
-      response.stubs(:body).returns(response_body)
-      response.stubs(:headers).returns({
-        "Link" => '</api/v1/registries/github%20actions/packages?page=2>; rel="next"'
+    should 'load GitHub Actions package names from each endpoint page' do
+      first_response = mock('first_response')
+      first_response.stubs(:success?).returns(true)
+      first_response.stubs(:body).returns(['actions/checkout', 'actions/setup-node'].to_json)
+      first_response.stubs(:headers).returns({
+        "Link" => '<https://packages.ecosyste.ms/api/v1/registries/github%20actions/package_names?per_page=10000&sort=name&order=asc&page=2>; rel="next"'
       })
 
       second_response = mock('second_response')
       second_response.stubs(:success?).returns(true)
-      second_response.stubs(:body).returns([].to_json)
+      second_response.stubs(:body).returns(['actions/upload-artifact'])
       second_response.stubs(:headers).returns({})
 
       conn = mock('connection')
-      conn.expects(:get).with("/api/v1/registries/github%20actions/packages?sort=updated_at&order=desc").returns(response)
-      conn.expects(:get).with('/api/v1/registries/github%20actions/packages?page=2').returns(second_response)
+      conn.expects(:get)
+        .with("/api/v1/registries/github%20actions/package_names?per_page=10000&sort=name&order=asc")
+        .returns(first_response)
+      conn.expects(:get)
+        .with('/api/v1/registries/github%20actions/package_names?per_page=10000&sort=name&order=asc&page=2')
+        .returns(second_response)
 
       Repository.stubs(:ecosystem_connection).returns(conn)
-      Host.stubs(:find_by_name).with("GitHub").returns(@host)
-      @host.expects(:find_repository).with("actions/checkout").returns(@repo)
-      @repo.expects(:download_tags).once
-      @repo.stubs(:tags).returns([])
 
-      # This should not raise NoMethodError: undefined method 'each' for String
-      assert_nothing_raised do
-        Repository.parse_dependencies_for_github_actions_tags
-      end
+      assert_equal Set.new([
+        'actions/checkout',
+        'actions/setup-node',
+        'actions/upload-artifact'
+      ]), Repository.github_actions_package_names
     end
 
-    should 'return nil when initial request is not successful' do
+    should 'return nil when the package names request is not successful' do
       response = mock('response')
       response.stubs(:success?).returns(false)
 
       conn = mock('connection')
-      conn.expects(:get).with("/api/v1/registries/github%20actions/packages?sort=updated_at&order=desc").returns(response)
+      conn.expects(:get)
+        .with("/api/v1/registries/github%20actions/package_names?per_page=10000&sort=name&order=asc")
+        .returns(response)
 
       Repository.stubs(:ecosystem_connection).returns(conn)
 
-      result = Repository.parse_dependencies_for_github_actions_tags
-      assert_nil result
+      assert_nil Repository.github_actions_package_names
     end
   end
 end

--- a/test/tasks/releases_rake_test.rb
+++ b/test/tasks/releases_rake_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+require 'rake'
+
+class ReleasesRakeTest < ActiveSupport::TestCase
+  setup do
+    Rails.application.load_tasks unless Rake::Task.task_defined?('releases:backfill_immutability')
+    Rake::Task['releases:backfill_immutability'].reenable
+  end
+
+  test 'backfill_immutability passes batch and resume arguments' do
+    Release.expects(:backfill_immutability)
+      .with(batch_size: 250, after_id: 1_000)
+      .yields(250, 20, 1_250)
+      .returns([250, 20, 1_250])
+
+    output = capture_io do
+      Rake::Task['releases:backfill_immutability'].invoke(250, 1_000)
+    end.first
+
+    assert_includes output, 'last id 1250'
+  end
+end

--- a/test/tasks/releases_rake_test.rb
+++ b/test/tasks/releases_rake_test.rb
@@ -7,16 +7,18 @@ class ReleasesRakeTest < ActiveSupport::TestCase
     Rake::Task['releases:backfill_immutability'].reenable
   end
 
-  test 'backfill_immutability passes batch and resume arguments' do
+  test 'backfill_immutability loads Action names and passes cursor arguments' do
+    repository_names = Set.new(['actions/checkout'])
+    Repository.expects(:github_actions_package_names).returns(repository_names)
     Release.expects(:backfill_immutability)
-      .with(batch_size: 250, after_id: 1_000)
-      .yields(250, 20, 1_250)
-      .returns([250, 20, 1_250])
+      .with(repository_names: repository_names, block_size: 250, after_name: 'actions/cache')
+      .yields(1, 1, 0, 'actions/checkout')
+      .returns([1, 1, 0, 'actions/checkout'])
 
     output = capture_io do
-      Rake::Task['releases:backfill_immutability'].invoke(250, 1_000)
+      Rake::Task['releases:backfill_immutability'].invoke(250, 'actions/cache')
     end.first
 
-    assert_includes output, 'last id 1250'
+    assert_includes output, 'last name actions/checkout'
   end
 end


### PR DESCRIPTION
Store the GitHub release `immutable` attribute and include it in release API responses. Refresh changed values during release sync. The backfill loads GitHub Actions names from the packages registry names endpoint and uses release cursors to sync only Actions repositories with unknown values.

Refs ecosyste-ms/packages#1757