### PR TITLE
Return 400 from repositories#lookup when url is unparseable

### DIFF
--- a/app/controllers/api/v1/repositories_controller.rb
+++ b/app/controllers/api/v1/repositories_controller.rb
@@ -79,7 +79,11 @@ class Api::V1::RepositoriesController < Api::V1::ApplicationController
   def lookup
     if params[:url].present?
       url = params[:url]
-      parsed_url = Addressable::URI.parse(url)
+      begin
+        parsed_url = Addressable::URI.parse(url)
+      rescue Addressable::URI::InvalidURIError => e
+        render json: { error: "Invalid url: #{e.message}" }, status: :bad_request and return
+      end
       @host = Host.find_by_domain(parsed_url.host)
       raise ActiveRecord::RecordNotFound unless @host
       path = parsed_url.path.delete_prefix('/').chomp('/')

--- a/test/controllers/api/v1/repositories_controller_test.rb
+++ b/test/controllers/api/v1/repositories_controller_test.rb
@@ -90,6 +90,13 @@ class ApiV1RepositoriesControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test 'lookup with an unparseable url returns 400' do
+    get api_v1_repositories_lookup_path(url: 'https://MenuellaFoodSafety (#14684)')
+    assert_response :bad_request
+    assert_equal 'application/json; charset=utf-8', @response.content_type
+    assert_match 'Invalid url', JSON.parse(@response.body)['error']
+  end
+
   test 'get a repository by purl' do
     get api_v1_repositories_lookup_path(purl: 'pkg:github/testuser/awesome-project')
     assert_response :success


### PR DESCRIPTION
`Addressable::URI.parse` raises `InvalidURIError` on inputs like `https://MenuellaFoodSafety (#14684)`, which was falling through to the exceptions app and rendering `500 {"error":"internal server error"}`. Callers can't distinguish that from a real server fault, so packages was retrying it indefinitely (~700/day of the current repos 500s). Return 400 with the parse error instead.

Companion to https://github.com/ecosyste-ms/packages/pull/1759 which stops packages sending these URLs in the first place.