### PR TITLE
Return 410 from disabled topic pages and skip host lookup

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -1,5 +1,5 @@
 class HostsController < ApplicationController
-  before_action :find_host_by_id, only: [:show, :topics, :topic]
+  before_action :find_host_by_id, only: [:show, :topics]
 
   def index
     redirect_to root_path
@@ -45,6 +45,6 @@ class HostsController < ApplicationController
     # TODO(DB_PERF): hosts#topic disabled 2026-01-10
     # topics @> ARRAY query on 297M rows is slow even with GIN index
     # Needs: composite index, materialized view, or pre-computed topic pages
-    render plain: "Topic pages temporarily unavailable", status: :service_unavailable
+    render plain: "Topic pages have been removed", status: :gone
   end
 end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -18,6 +18,6 @@ class TopicsController < ApplicationController
     # topics @> ARRAY query on 297M rows is slow even with GIN index
     # Combined with ORDER BY stargazers_count, it causes 15+ minute queries
     # Needs: composite index, materialized view, or pre-computed topic pages
-    render plain: "Topic pages temporarily unavailable", status: :service_unavailable
+    render plain: "Topic pages have been removed", status: :gone
   end
 end

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -21,6 +21,17 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'topic show is disabled and returns 410' do
+    get topic_path(id: 'ruby')
+    assert_response :gone
+  end
+
+  test 'host topic is disabled and returns 410 without loading the host' do
+    get topic_host_path(id: @host.name, topic: 'ruby')
+    assert_response :gone
+    assert_nil assigns(:host)
+  end
+
   test 'topics index excludes blocked topics' do
     Topic.create!(host: @host, name: 'malwarebytes-unlocked-version', repositories_count: 10)
     Topic.create!(host: @host, name: 'good-topic', repositories_count: 5)


### PR DESCRIPTION
`topics#show` and `hosts#topic` have been stubbed since 2026-01-10 because the `topics @> ARRAY` query on 297M rows takes 15+ minutes. They currently return 503, which shows up as ~3,100 5xx/day at the gateway and tells crawlers to retry.

Return 410 Gone instead so search engines drop the URLs and the responses stop counting as server errors. Also drop `:topic` from the `find_host_by_id` before_action so the stub doesn't wait on a DB connection when the pool is saturated by slow API queries; some of these were taking 5-11s just to render "unavailable".