### PR TITLE
Continue release backfill after GitHub errors

### DIFF
--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -5,16 +5,18 @@ class Release < ApplicationRecord
     raise ArgumentError, 'block_size must be greater than zero' unless block_size.positive?
 
     host = Host.find_by_name('GitHub')
-    return [0, 0, 0, after_name] unless host
+    return [0, 0, 0, after_name, 0] unless host
 
     names = repository_names.compact.uniq.sort_by(&:downcase)
     names = names.drop_while { |name| name.downcase <= after_name.downcase } if after_name.present?
     processed = 0
     repositories_synced = 0
     repositories_missing = 0
+    repositories_failed = 0
     last_name = after_name
 
     names.each do |name|
+      sync_error = nil
       repository = host.find_repository(name)
       if repository
         needs_backfill = false
@@ -23,8 +25,13 @@ class Release < ApplicationRecord
         end
 
         if needs_backfill
-          repository.download_releases
-          repositories_synced += 1
+          begin
+            repository.download_releases
+            repositories_synced += 1
+          rescue Octokit::ServerError, Faraday::TimeoutError, Faraday::ConnectionFailed, Net::OpenTimeout, Socket::ResolutionError => error
+            repositories_failed += 1
+            sync_error = error
+          end
         end
       else
         repositories_missing += 1
@@ -32,12 +39,12 @@ class Release < ApplicationRecord
 
       processed += 1
       last_name = name
-      if block_given? && (processed == 1 || (processed % 100).zero?)
-        yield(processed, repositories_synced, repositories_missing, last_name)
+      if block_given? && (sync_error || processed == 1 || (processed % 100).zero?)
+        yield(processed, repositories_synced, repositories_missing, last_name, repositories_failed, sync_error)
       end
     end
 
-    [processed, repositories_synced, repositories_missing, last_name]
+    [processed, repositories_synced, repositories_missing, last_name, repositories_failed]
   end
 
   def to_s

--- a/lib/tasks/releases.rake
+++ b/lib/tasks/releases.rake
@@ -6,13 +6,14 @@ namespace :releases do
     abort 'Unable to load GitHub Actions package names' unless repository_names
 
     puts "Loaded #{repository_names.size} GitHub Actions package names"
-    processed, repositories_synced, repositories_missing, last_name = Release.backfill_immutability(
+    processed, repositories_synced, repositories_missing, last_name, repositories_failed = Release.backfill_immutability(
       repository_names: repository_names,
       block_size: block_size,
       after_name: args[:after_name]
-    ) do |current_processed, current_synced, current_missing, current_name|
-      puts "Processed #{current_processed} names, synced #{current_synced} repositories, missing #{current_missing}, last name #{current_name}"
+    ) do |current_processed, current_synced, current_missing, current_name, current_failed, error|
+      puts "Processed #{current_processed} names, synced #{current_synced} repositories, missing #{current_missing}, failed #{current_failed}, last name #{current_name}"
+      warn "Failed to sync #{current_name}: #{error.class}: #{error.message}" if error
     end
-    puts "Done: processed #{processed} names, synced #{repositories_synced} repositories, missing #{repositories_missing}; last name #{last_name}"
+    puts "Done: processed #{processed} names, synced #{repositories_synced} repositories, missing #{repositories_missing}, failed #{repositories_failed}; last name #{last_name}"
   end
 end

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -66,7 +66,7 @@ class ReleaseTest < ActiveSupport::TestCase
     end
     transaction_count = Release.connection.open_transactions
 
-    processed, repositories_synced, repositories_missing, last_name = Release.backfill_immutability(
+    processed, repositories_synced, repositories_missing, last_name, repositories_failed = Release.backfill_immutability(
       repository_names: repository_names,
       block_size: 1
     )
@@ -77,6 +77,7 @@ class ReleaseTest < ActiveSupport::TestCase
     assert_equal 2, repositories_synced
     assert_equal 1, repositories_missing
     assert_equal repository_names.sort_by(&:downcase).last, last_name
+    assert_equal 0, repositories_failed
   end
 
   test 'backfill_immutability rejects an empty batch' do
@@ -100,5 +101,32 @@ class ReleaseTest < ActiveSupport::TestCase
     repository.expects(:download_releases)
 
     Release.backfill_immutability(repository_names: ['actions/checkout'])
+  end
+
+  test 'backfill_immutability continues after a GitHub server error' do
+    github_host = create(:github_host)
+    failing_repository = create(:repository, host: github_host, full_name: 'actions/failing')
+    following_repository = create(:repository, host: github_host, full_name: 'actions/following')
+    create(:release, repository: failing_repository, immutable: nil)
+    create(:release, repository: following_repository, immutable: nil)
+    error = Octokit::ServerError.new(status: 504, body: 'timeout')
+
+    Host.stubs(:find_by_name).with('GitHub').returns(github_host)
+    github_host.stubs(:find_repository).with(failing_repository.full_name).returns(failing_repository)
+    github_host.stubs(:find_repository).with(following_repository.full_name).returns(following_repository)
+    failing_repository.expects(:download_releases).raises(error)
+    following_repository.expects(:download_releases)
+    progress = []
+
+    result = Release.backfill_immutability(
+      repository_names: [failing_repository.full_name, following_repository.full_name]
+    ) do |*values|
+      progress << values
+    end
+
+    assert_equal [2, 1, 0, following_repository.full_name, 1], result
+    assert_equal failing_repository.full_name, progress.first[3]
+    assert_equal 1, progress.first[4]
+    assert_equal error, progress.first[5]
   end
 end

--- a/test/tasks/releases_rake_test.rb
+++ b/test/tasks/releases_rake_test.rb
@@ -12,13 +12,31 @@ class ReleasesRakeTest < ActiveSupport::TestCase
     Repository.expects(:github_actions_package_names).returns(repository_names)
     Release.expects(:backfill_immutability)
       .with(repository_names: repository_names, block_size: 250, after_name: 'actions/cache')
-      .yields(1, 1, 0, 'actions/checkout')
-      .returns([1, 1, 0, 'actions/checkout'])
+      .yields(1, 1, 0, 'actions/checkout', 0, nil)
+      .returns([1, 1, 0, 'actions/checkout', 0])
 
     output = capture_io do
       Rake::Task['releases:backfill_immutability'].invoke(250, 'actions/cache')
     end.first
 
     assert_includes output, 'last name actions/checkout'
+    assert_includes output, 'failed 0'
+  end
+
+  test 'backfill_immutability reports repository sync failures' do
+    repository_names = Set.new(['actions/failing'])
+    error = Octokit::ServerError.new(status: 504, body: 'timeout')
+    Repository.expects(:github_actions_package_names).returns(repository_names)
+    Release.expects(:backfill_immutability)
+      .with(repository_names: repository_names, block_size: 1_000, after_name: nil)
+      .yields(1, 0, 0, 'actions/failing', 1, error)
+      .returns([1, 0, 0, 'actions/failing', 1])
+
+    output, errors = capture_io do
+      Rake::Task['releases:backfill_immutability'].invoke
+    end
+
+    assert_includes output, 'failed 1'
+    assert_includes errors, 'Failed to sync actions/failing: Octokit::ServerError'
   end
 end


### PR DESCRIPTION
Continue the release immutability backfill when GitHub returns a server error or a request times out or loses its connection. Report the failed repository immediately and include a failure count in progress and final output, while leaving database and application errors fatal.

Follow-up to #1172.