### PR TITLE
Remove orphaned GitHub tags and releases during sync

### DIFF
--- a/app/models/hosts/github.rb
+++ b/app/models/hosts/github.rb
@@ -183,7 +183,15 @@ module Hosts
         Tag.insert_all(tag_records)
       end
 
-      repository.tags.where.not(name: remote_names).delete_all if complete
+      if complete
+        orphan_tag_ids = repository.tags.where.not(name: remote_names).pluck(:id)
+        if orphan_tag_ids.any?
+          orphan_manifest_ids = Manifest.where(tag_id: orphan_tag_ids).pluck(:id)
+          Dependency.where(manifest_id: orphan_manifest_ids).delete_all if orphan_manifest_ids.any?
+          Manifest.where(id: orphan_manifest_ids).delete_all if orphan_manifest_ids.any?
+          Tag.where(id: orphan_tag_ids).delete_all
+        end
+      end
 
       repository.update_columns(tags_last_synced_at: now, tags_count: repository.tags.count)
     rescue *IGNORABLE_EXCEPTIONS, Octokit::NotFound, Octokit::RepositoryUnavailable, Octokit::UnavailableForLegalReasons

--- a/app/models/hosts/github.rb
+++ b/app/models/hosts/github.rb
@@ -154,41 +154,44 @@ module Hosts
     end
 
     def download_tags(repository)
-      tags = fetch_tags(repository)
+      tags, complete = fetch_tags(repository)
       return unless tags.present?
-      
-      # Get existing tag names in one query
-      existing_names = repository.tags.pluck(:name).to_set
-      
-      # Filter out existing tags
-      new_tags = Array(tags).reject { |tag| existing_names.include?(tag[:name]) }
-      
-      if new_tags.any?
-        # Prepare records for bulk insert
-        tag_records = new_tags.map do |tag|
-          tag.merge(
-            repository_id: repository.id,
-            created_at: Time.current,
-            updated_at: Time.current
-          )
-        end
-        
-        # Bulk insert new tags only
-        Tag.insert_all(tag_records)
-        
-        # Update count incrementally
-        new_count = (repository.tags_count || 0) + new_tags.size
-        repository.update_columns(tags_last_synced_at: Time.current, tags_count: new_count)
-      else
-        # No new tags, just update sync time
-        repository.update_columns(tags_last_synced_at: Time.current)
+
+      now = Time.current
+      existing_tags = repository.tags.pluck(:name, :sha).to_h
+      remote_names = tags.map { |tag| tag[:name] }
+
+      moved_tags = tags.select do |tag|
+        existing_tags.key?(tag[:name]) && existing_tags[tag[:name]] != tag[:sha]
       end
+      moved_tags.each do |tag|
+        repository.tags.where(name: tag[:name]).update_all(
+          sha: tag[:sha],
+          kind: tag[:kind],
+          published_at: tag[:published_at],
+          dependencies_parsed_at: nil,
+          dependency_job_id: nil,
+          updated_at: now
+        )
+      end
+
+      new_tags = tags.reject { |tag| existing_tags.key?(tag[:name]) }
+      if new_tags.any?
+        tag_records = new_tags.map do |tag|
+          tag.merge(repository_id: repository.id, created_at: now, updated_at: now)
+        end
+        Tag.insert_all(tag_records)
+      end
+
+      repository.tags.where.not(name: remote_names).delete_all if complete
+
+      repository.update_columns(tags_last_synced_at: now, tags_count: repository.tags.count)
     rescue *IGNORABLE_EXCEPTIONS, Octokit::NotFound, Octokit::RepositoryUnavailable, Octokit::UnavailableForLegalReasons
       nil
     end
 
     def download_releases(repository)
-      releases = fetch_releases(repository)
+      releases, complete = fetch_releases(repository)
       return unless releases.present?
 
       # Get existing release UUIDs in one query
@@ -227,6 +230,8 @@ module Hosts
         Release.insert_all(release_records)
       end
 
+      repository.releases.where.not(uuid: release_uuids).delete_all if complete
+
       nil
     rescue *IGNORABLE_EXCEPTIONS, Octokit::NotFound, Octokit::RepositoryUnavailable, Octokit::UnavailableForLegalReasons
       nil
@@ -245,8 +250,9 @@ module Hosts
         releases.concat(last_resp.data)
         pages_fetched += 1
       end
+      complete = last_resp.rels[:next].blank?
 
-      releases.map do |release|
+      mapped = releases.map do |release|
         {
           uuid: release.id,
           tag_name: release.tag_name,
@@ -263,8 +269,9 @@ module Hosts
           last_synced_at: Time.now
         }
       end
+      [mapped, complete]
     rescue *IGNORABLE_EXCEPTIONS, Octokit::NotFound, Octokit::UnprocessableEntity, Octokit::RepositoryUnavailable, Octokit::UnavailableForLegalReasons
-      []
+      [[], false]
     end
 
     def load_owner_repos_names(owner, max_pages: 10)
@@ -288,17 +295,18 @@ module Hosts
 
     def fetch_tags(repository, max_pages: 10)
       tags = []
-      fetch_tags_graphql(repository).tap do |res|
-        return if res[:data].nil? || res[:data][:repository].nil? || res[:data][:repository][:refs].nil?
+      res = fetch_tags_graphql(repository)
+      return [nil, false] if res[:data].nil? || res[:data][:repository].nil? || res[:data][:repository][:refs].nil?
+
+      tags += map_tags(res)
+      pages_fetched = 1
+      while pages_fetched < max_pages && res.dig(:data, :repository, :refs, :pageInfo, :hasNextPage)
+        res = fetch_tags_graphql(repository, res[:data][:repository][:refs][:pageInfo][:endCursor])
         tags += map_tags(res)
-        pages_fetched = 1
-        while pages_fetched < max_pages && res.dig(:data, :repository, :refs, :pageInfo, :hasNextPage)
-          res = fetch_tags_graphql(repository, res[:data][:repository][:refs][:pageInfo][:endCursor])
-          tags += map_tags(res)
-          pages_fetched += 1
-        end
+        pages_fetched += 1
       end
-      tags
+      complete = !res.dig(:data, :repository, :refs, :pageInfo, :hasNextPage)
+      [tags, complete]
     end
 
     def fetch_tags_graphql(repository, cursor = nil)

--- a/test/models/hosts/github_test.rb
+++ b/test/models/hosts/github_test.rb
@@ -33,12 +33,13 @@ class Hosts::GithubTest < ActiveSupport::TestCase
 
       @github.stubs(:api_client).with(nil, auto_paginate: false).returns(client)
 
-      result = @github.fetch_releases(@repository)
+      result, complete = @github.fetch_releases(@repository)
 
       assert_equal 1, result.length
       assert_equal 1, result.first[:uuid]
       assert_equal 'v1.0.0', result.first[:tag_name]
       assert result.first[:immutable]
+      assert complete
     end
 
     should 'stop after max_pages' do
@@ -69,11 +70,32 @@ class Hosts::GithubTest < ActiveSupport::TestCase
 
       @github.stubs(:api_client).with(nil, auto_paginate: false).returns(client)
 
-      result = @github.fetch_releases(@repository, max_pages: 2)
+      result, complete = @github.fetch_releases(@repository, max_pages: 2)
 
       assert_equal 2, result.length
       assert_equal 'v1.0', result.first[:tag_name]
       assert_equal 'v2.0', result.last[:tag_name]
+      assert complete
+    end
+
+    should 'report incomplete when max_pages leaves a next link' do
+      release = OpenStruct.new(
+        id: 1, tag_name: 'v1.0', target_commitish: 'main', name: 'r', body: 'b',
+        draft: false, prerelease: false, immutable: false, created_at: Time.now, published_at: Time.now,
+        author: OpenStruct.new(login: 'u'), assets: []
+      )
+      next_rel = mock('next_rel')
+      last_response = mock('last_response')
+      last_response.stubs(:rels).returns({ next: next_rel })
+      client = mock('client')
+      client.expects(:releases).with('testuser/testrepo', per_page: 100).returns([release])
+      client.stubs(:last_response).returns(last_response)
+      @github.stubs(:api_client).with(nil, auto_paginate: false).returns(client)
+
+      result, complete = @github.fetch_releases(@repository, max_pages: 1)
+
+      assert_equal 1, result.length
+      assert_not complete
     end
 
     should 'return empty array on error' do
@@ -81,9 +103,10 @@ class Hosts::GithubTest < ActiveSupport::TestCase
       client.expects(:releases).raises(Octokit::NotFound)
       @github.stubs(:api_client).with(nil, auto_paginate: false).returns(client)
 
-      result = @github.fetch_releases(@repository)
+      result, complete = @github.fetch_releases(@repository)
 
       assert_equal [], result
+      assert_not complete
     end
   end
 
@@ -107,11 +130,11 @@ class Hosts::GithubTest < ActiveSupport::TestCase
         updated_at: unchanged_updated_at
       )
 
-      @github.stubs(:fetch_releases).with(@repository).returns([
+      @github.stubs(:fetch_releases).with(@repository).returns([[
         { uuid: 1, tag_name: 'v1.0.0', immutable: true, last_synced_at: Time.current },
         { uuid: 2, tag_name: 'v2.0.0', immutable: false, last_synced_at: Time.current },
         { uuid: 3, tag_name: 'v3.0.0', immutable: false, last_synced_at: Time.current }
-      ])
+      ], true])
 
       @github.download_releases(@repository)
 
@@ -120,6 +143,35 @@ class Hosts::GithubTest < ActiveSupport::TestCase
       assert_not @repository.releases.find_by!(uuid: '3').immutable
       assert_operator existing_release.last_synced_at, :>, 2.days.ago
       assert_equal unchanged_updated_at, unchanged_release.reload.updated_at
+    end
+
+    should 'delete releases GitHub no longer returns when the fetch is complete' do
+      kept = create(:release, repository: @repository, uuid: '1', tag_name: 'v2', immutable: false)
+      orphan = create(:release, repository: @repository, uuid: '99', tag_name: 'v2', immutable: nil)
+
+      @github.stubs(:fetch_releases).with(@repository).returns([[
+        { uuid: 1, tag_name: 'v2', immutable: false, last_synced_at: Time.current }
+      ], true])
+
+      @github.download_releases(@repository)
+
+      assert Release.exists?(kept.id)
+      assert_not Release.exists?(orphan.id)
+      assert_equal 1, @repository.releases.count
+    end
+
+    should 'keep releases GitHub did not return when the fetch was truncated' do
+      kept = create(:release, repository: @repository, uuid: '1', tag_name: 'v1')
+      beyond_page_cap = create(:release, repository: @repository, uuid: '99', tag_name: 'v0.1')
+
+      @github.stubs(:fetch_releases).with(@repository).returns([[
+        { uuid: 1, tag_name: 'v1', immutable: false, last_synced_at: Time.current }
+      ], false])
+
+      @github.download_releases(@repository)
+
+      assert Release.exists?(kept.id)
+      assert Release.exists?(beyond_page_cap.id)
     end
   end
 
@@ -140,11 +192,12 @@ class Hosts::GithubTest < ActiveSupport::TestCase
 
       @github.expects(:fetch_tags_graphql).with(@repository).returns(graphql_response)
 
-      result = @github.fetch_tags(@repository)
+      result, complete = @github.fetch_tags(@repository)
 
       assert_equal 1, result.length
       assert_equal 'v1.0.0', result.first[:name]
       assert_equal 'sha1', result.first[:sha]
+      assert complete
     end
 
     should 'stop after max_pages' do
@@ -177,19 +230,57 @@ class Hosts::GithubTest < ActiveSupport::TestCase
       @github.expects(:fetch_tags_graphql).with(@repository).returns(page1_response)
       @github.expects(:fetch_tags_graphql).with(@repository, 'cursor1').returns(page2_response)
 
-      result = @github.fetch_tags(@repository, max_pages: 2)
+      result, complete = @github.fetch_tags(@repository, max_pages: 2)
 
       assert_equal 2, result.length
       assert_equal 'v1.0', result.first[:name]
       assert_equal 'v2.0', result.last[:name]
+      assert_not complete
     end
 
     should 'return nil when graphql returns no data' do
       @github.expects(:fetch_tags_graphql).with(@repository).returns({ data: nil })
 
-      result = @github.fetch_tags(@repository)
+      result, complete = @github.fetch_tags(@repository)
 
       assert_nil result
+      assert_not complete
+    end
+  end
+
+  context 'download_tags' do
+    should 'update moved tags, delete orphans and insert new tags when the fetch is complete' do
+      moved = create(:tag, repository: @repository, name: 'v2', sha: 'oldsha', dependencies_parsed_at: 1.day.ago, dependency_job_id: 'job')
+      orphan = create(:tag, repository: @repository, name: 'gone', sha: 'deadsha')
+      @repository.update_columns(tags_count: 2)
+
+      @github.stubs(:fetch_tags).with(@repository).returns([[
+        { name: 'v2', sha: 'newsha', kind: 'commit', published_at: Time.current },
+        { name: 'v2.1', sha: 'abc', kind: 'commit', published_at: Time.current }
+      ], true])
+
+      @github.download_tags(@repository)
+
+      moved.reload
+      assert_equal 'newsha', moved.sha
+      assert_nil moved.dependencies_parsed_at
+      assert_nil moved.dependency_job_id
+      assert_not Tag.exists?(orphan.id)
+      assert @repository.tags.exists?(name: 'v2.1')
+      assert_equal 2, @repository.reload.tags_count
+    end
+
+    should 'keep tags GitHub did not return when the fetch was truncated' do
+      beyond_page_cap = create(:tag, repository: @repository, name: 'v0.0.1', sha: 'oldsha')
+
+      @github.stubs(:fetch_tags).with(@repository).returns([[
+        { name: 'v2', sha: 'abc', kind: 'commit', published_at: Time.current }
+      ], false])
+
+      @github.download_tags(@repository)
+
+      assert Tag.exists?(beyond_page_cap.id)
+      assert_equal 2, @repository.reload.tags_count
     end
   end
 

--- a/test/models/hosts/github_test.rb
+++ b/test/models/hosts/github_test.rb
@@ -251,7 +251,10 @@ class Hosts::GithubTest < ActiveSupport::TestCase
   context 'download_tags' do
     should 'update moved tags, delete orphans and insert new tags when the fetch is complete' do
       moved = create(:tag, repository: @repository, name: 'v2', sha: 'oldsha', dependencies_parsed_at: 1.day.ago, dependency_job_id: 'job')
+      kept_manifest = create(:manifest, repository: nil, tag: moved)
       orphan = create(:tag, repository: @repository, name: 'gone', sha: 'deadsha')
+      orphan_manifest = create(:manifest, repository: nil, tag: orphan)
+      orphan_dependency = create(:dependency, repository: @repository, manifest: orphan_manifest)
       @repository.update_columns(tags_count: 2)
 
       @github.stubs(:fetch_tags).with(@repository).returns([[
@@ -265,7 +268,10 @@ class Hosts::GithubTest < ActiveSupport::TestCase
       assert_equal 'newsha', moved.sha
       assert_nil moved.dependencies_parsed_at
       assert_nil moved.dependency_job_id
+      assert Manifest.exists?(kept_manifest.id)
       assert_not Tag.exists?(orphan.id)
+      assert_not Manifest.exists?(orphan_manifest.id)
+      assert_not Dependency.exists?(orphan_dependency.id)
       assert @repository.tags.exists?(name: 'v2.1')
       assert_equal 2, @repository.reload.tags_count
     end


### PR DESCRIPTION
Repos that delete and recreate a moving release (e.g. `action-pack/increment` republishes `v2` on every point release) accumulate stale release rows that `download_releases` never touches again, which is why the immutability backfill left ~2% of Actions release rows at nil. Moving tags had the same problem with a stale sha.

`fetch_tags` / `fetch_releases` now return whether pagination reached the end. When it did, `download_tags` / `download_releases` delete rows GitHub no longer returns; when the fetch hit `max_pages` nothing is deleted so rows beyond page 10 are safe. `download_tags` also refreshes the sha on moved tags (clearing `dependencies_parsed_at` so they reparse) and sets `tags_count` from a real count so deletes don't cause drift.

GitHub only. Re-running `releases:backfill_immutability` or normal tag sync traffic will clear the orphans as it goes.

Follows #1172.