### PR TITLE
Ping packages after repository metadata enrichment

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -435,9 +435,11 @@ class Repository < ApplicationRecord
   def update_metadata_files
     metadata_files = fetch_metadata_files_list
     return if metadata_files.nil?
+    previous_metadata = metadata.deep_stringify_keys
     metadata["files"] = metadata_files
     save
     parse_funding
+    ping_packages_async if metadata.deep_stringify_keys != previous_metadata
   end
 
   def parse_funding

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -742,6 +742,31 @@ class RepositoryTest < ActiveSupport::TestCase
     end
   end
 
+  context 'update_metadata_files method' do
+    setup do
+      @repository = create(:repository, metadata: {})
+    end
+
+    should 'ping packages after changed funding metadata is saved' do
+      @repository.stubs(:fetch_metadata_files_list).returns(funding: '.github/FUNDING.yml')
+      @repository.stubs(:related_dot_github_repo).returns(nil)
+      @repository.stubs(:get_file_contents).with('.github/FUNDING.yml').returns(content: "github: example\n")
+      @repository.expects(:ping_packages_async).once
+
+      @repository.update_metadata_files
+
+      assert_equal({ 'github' => 'example' }, @repository.reload.metadata['funding'])
+    end
+
+    should 'not ping packages when metadata is unchanged' do
+      @repository.update!(metadata: { 'files' => { 'funding' => nil } })
+      @repository.stubs(:fetch_metadata_files_list).returns(funding: nil)
+      @repository.expects(:ping_packages_async).never
+
+      @repository.update_metadata_files
+    end
+  end
+
   context 'transform_funding_json method' do
     setup do
       @host = create(:host)


### PR DESCRIPTION
Related to ecosyste-ms/packages#1793.

Repository sync pings packages before the asynchronous metadata-file and funding enrichment has completed. This sends another packages ping when enrichment changes stored metadata, after those changes are saved. Unchanged metadata does not send another ping.