### PR TITLE
Prevent caching internal server errors

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -16,6 +16,9 @@ class ErrorsController < ApplicationController
   end
 
   def internal
+    response.cache_control.replace({ no_store: true })
+    response.headers.delete('CDN-Cache-Control')
+
     respond_to do |format|
       format.html { render status: :internal_server_error }
       format.json { render json: { error: "internal server error" }, status: :internal_server_error }

--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -17,5 +17,7 @@ class ErrorsControllerTest < ActionDispatch::IntegrationTest
     get '/500'
     assert_response :internal_server_error
     assert_template 'errors/internal'
+    assert_equal 'no-store', response.headers['Cache-Control']
+    assert_nil response.headers['CDN-Cache-Control']
   end
 end


### PR DESCRIPTION
Internal server errors currently inherit public CDN cache headers, allowing a transient origin failure to be cached for four hours and served stale for a day. Return them with `Cache-Control: no-store` and remove `CDN-Cache-Control`.