### PR TITLE
Set 14s statement_timeout for web processes only

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: bundle exec puma -C config/puma.rb
+web: STATEMENT_TIMEOUT=14s bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -C config/sidekiq.yml
 release: bundle exec rake db:migrate
 import: bundle exec rake import:github_from_timeline

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,7 +8,7 @@ default: &default
   port:     <%= ENV.fetch("POSTGRES_PORT") { '' } %>
   pool:     <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   variables:
-    statement_timeout: '300s'
+    statement_timeout: <%= ENV.fetch("STATEMENT_TIMEOUT") { '300s' } %>
 
 development:
   <<: *default


### PR DESCRIPTION
rack-timeout kills requests at 15s but the postgres backend keeps running until the 300s `statement_timeout`, so a slow query (currently `SELECT * FROM repositories WHERE host_id = ? ORDER BY stargazers_count DESC` from `Api::V1::RepositoriesController#index` with `?sort=stargazers_count`, no supporting index on a 280M-row table) leaves zombie backends that pile up, saturate DB IO, and push unrelated requests past the rack-timeout ceiling. That's the current source of the 500s Packages is seeing on `/api/v1/repositories/lookup`.

Read `statement_timeout` from `STATEMENT_TIMEOUT` with the existing 300s as default, and set `STATEMENT_TIMEOUT=14s` only in the `web:` Procfile line so puma connections cancel just before rack-timeout fires. Sidekiq workers, rake tasks and `rails console` keep 300s.

This stops the cascade; the offending requests will still 500 until the `sort` param is restricted to indexed columns (separate change).