### PR TITLE
Set STATEMENT_TIMEOUT in puma.rb instead of Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: STATEMENT_TIMEOUT=14s bundle exec puma -C config/puma.rb
+web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -C config/sidekiq.yml
 release: bundle exec rake db:migrate
 import: bundle exec rake import:github_from_timeline

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,9 @@
+# Cap postgres statement_timeout below rack-timeout's 15s so a slow query
+# is cancelled server-side instead of leaving a zombie backend after the
+# request is killed. Only puma reads this file so sidekiq, rake and console
+# keep the database.yml default.
+ENV["STATEMENT_TIMEOUT"] ||= "14s"
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match


### PR DESCRIPTION
Follow-up to #1180 which failed to deploy: dokku's Dockerfile scheduler execs the Procfile line via tini without a shell, so `VAR=val cmd` tried to exec a binary called `STATEMENT_TIMEOUT=14s` and the web containers crash-looped (zero-downtime checks caught it, prod unaffected).

Set the env var at the top of `config/puma.rb` instead. Puma evaluates its config file before booting the Rails app, so `database.yml` picks it up, and only the web process loads this file so sidekiq, rake and console keep the 300s default. `||=` still allows override via `dokku config:set`.