### PR TITLE
Add weekly GitHub DMCA sweep

### DIFF
--- a/app.json
+++ b/app.json
@@ -57,6 +57,10 @@
       "schedule": "0 0 * * 0"
     },
     {
+      "command": "bundle exec rake takedown:sweep_github_dmca",
+      "schedule": "0 1 * * 0"
+    },
+    {
       "command": "bundle exec rake gharchive:import_recent",
       "schedule": "0 * * * *"
     },

--- a/app/services/github_dmca_sweeper.rb
+++ b/app/services/github_dmca_sweeper.rb
@@ -1,0 +1,118 @@
+require "base64"
+
+class GithubDmcaSweeper
+  DMCA_REPOSITORY = "github/dmca"
+  CURSOR_KEY = "takedown:github_dmca:last_sha"
+  MAX_COMPARISON_FILES = 300
+  NOTICE_PATH = %r{\A\d{4}/(?:\d{2}/)?.+\.(?:md|markdown)\z}i
+  GITHUB_REPOSITORY_URL = %r{https?://github\.com/([a-z0-9][a-z0-9-]*)/([a-z0-9_.-]+)}i
+
+  def initialize(host: nil, client: nil, redis: REDIS, output: $stdout)
+    @host = host || Host.find_by_name!("GitHub")
+    @client = client || github_client
+    @redis = redis
+    @output = output
+  end
+
+  def sweep
+    head_sha = current_head_sha
+    base_sha = @redis.get(CURSOR_KEY)
+    base_sha ||= baseline_sha
+
+    if base_sha == head_sha
+      @redis.set(CURSOR_KEY, head_sha)
+      return result(head_sha: head_sha)
+    end
+
+    comparison = @client.compare(DMCA_REPOSITORY, base_sha, head_sha)
+    files = comparison.files.to_a
+    if files.length >= MAX_COMPARISON_FILES
+      raise "GitHub DMCA comparison reached the #{MAX_COMPARISON_FILES}-file limit"
+    end
+
+    notice_files = files.select { |file| notice_file?(file) }
+    repository_names = repository_names_from(notice_files, head_sha)
+    indexed_count = 0
+    removed_count = 0
+
+    repository_names.each do |repository_name|
+      repository = @host.find_repository(repository_name)
+      next unless repository
+
+      indexed_count += 1
+      begin
+        @client.repository(repository_name)
+      rescue Octokit::UnavailableForLegalReasons
+        @output.puts "[repos] removing #{repository.full_name} listed in github/dmca"
+        repository.destroy!
+        removed_count += 1
+      end
+    end
+
+    @redis.set(CURSOR_KEY, head_sha)
+    result(
+      head_sha: head_sha,
+      notice_files: notice_files.length,
+      candidates: repository_names.length,
+      indexed: indexed_count,
+      removed: removed_count
+    )
+  end
+
+  def github_client
+    token = @host.host_instance.fetch_random_token
+    options = {}
+    options[:access_token] = token if token.present?
+    Octokit::Client.new(options)
+  end
+
+  def current_head_sha
+    repository = @client.repository(DMCA_REPOSITORY)
+    reference = @client.ref(DMCA_REPOSITORY, "heads/#{repository.default_branch}")
+    reference.object.sha
+  end
+
+  def baseline_sha
+    commit = @client.commits(
+      DMCA_REPOSITORY,
+      until: 1.week.ago.iso8601,
+      per_page: 1
+    ).first
+    raise "Unable to find a GitHub DMCA baseline commit" unless commit
+
+    commit.sha
+  end
+
+  def notice_file?(file)
+    file.status != "removed" && file.filename.match?(NOTICE_PATH)
+  end
+
+  def repository_names_from(files, head_sha)
+    names = files.flat_map do |file|
+      response = @client.contents(DMCA_REPOSITORY, path: file.filename, ref: head_sha)
+      repository_names_in(Base64.decode64(response.content))
+    end
+
+    names.each_with_object({}) do |name, unique_names|
+      unique_names[name.downcase] ||= name
+    end.values
+  end
+
+  def repository_names_in(content)
+    content.scan(GITHUB_REPOSITORY_URL).filter_map do |owner, repository|
+      repository = repository.sub(/[.,;:]+\z/, "").delete_suffix(".git")
+      name = "#{owner}/#{repository}"
+      name unless name.casecmp?(DMCA_REPOSITORY)
+    end
+  end
+
+  def result(head_sha:, notice_files: 0, candidates: 0, indexed: 0, removed: 0)
+    {
+      head_sha: head_sha,
+      notice_files: notice_files,
+      candidates: candidates,
+      indexed: indexed,
+      removed: removed
+    }
+  end
+end

--- a/lib/tasks/takedown.rake
+++ b/lib/tasks/takedown.rake
@@ -1,4 +1,16 @@
+require_relative '../cron_lock'
+
 namespace :takedown do
+  desc "Remove indexed repositories blocked by new notices in github/dmca"
+  task sweep_github_dmca: :environment do
+    ActiveRecord::Base.connection.execute("SET statement_timeout = 0")
+
+    CronLock.acquire("takedown:sweep_github_dmca", ttl: 1.hour) do
+      result = GithubDmcaSweeper.new.sweep
+      puts "[repos] github/dmca notices=#{result[:notice_files]} candidates=#{result[:candidates]} indexed=#{result[:indexed]} removed=#{result[:removed]}"
+    end
+  end
+
   desc "Hide a user and remove their repositories. LOGIN=username [HOST=GitHub]"
   task hide_user: :environment do
     login = ENV['LOGIN']

--- a/test/services/github_dmca_sweeper_test.rb
+++ b/test/services/github_dmca_sweeper_test.rb
@@ -1,0 +1,122 @@
+require "test_helper"
+
+class GithubDmcaSweeperTest < ActiveSupport::TestCase
+  setup do
+    @host = create(:github_host)
+    @redis = mock("redis")
+    @client = mock("octokit client")
+    @output = StringIO.new
+    @sweeper = GithubDmcaSweeper.new(
+      host: @host,
+      client: @client,
+      redis: @redis,
+      output: @output
+    )
+  end
+
+  test "removes only indexed repositories blocked for legal reasons" do
+    blocked = create(:repository, host: @host, full_name: "Blocked/Repo", owner: "Blocked")
+    original = create(:repository, host: @host, full_name: "Original/Work", owner: "Original")
+    create(:repository, host: @host, full_name: "Unrelated/Repo", owner: "Unrelated")
+
+    expect_comparison(<<~NOTICE)
+      Original work: https://github.com/Original/Work
+      Infringing file: https://github.com/Blocked/Repo/blob/main/copied.rb
+      Duplicate link: https://github.com/blocked/repo
+      Notice help: https://github.com/github/dmca/blob/master/README.md
+      Profile only: https://github.com/Someone
+    NOTICE
+
+    @client.expects(:repository).with("Original/Work").returns(stub)
+    @client.expects(:repository).with("Blocked/Repo").raises(Octokit::UnavailableForLegalReasons)
+
+    result = @sweeper.sweep
+
+    assert_nil Repository.find_by(id: blocked.id)
+    assert Repository.exists?(original.id)
+    assert_equal 1, result[:notice_files]
+    assert_equal 2, result[:candidates]
+    assert_equal 2, result[:indexed]
+    assert_equal 1, result[:removed]
+    assert_includes @output.string, "removing Blocked/Repo"
+  end
+
+  test "ignores non-notice and removed files" do
+    @redis.expects(:get).with(GithubDmcaSweeper::CURSOR_KEY).returns("base-sha")
+    expect_head
+    comparison = stub(files: [
+      stub(filename: "README.md", status: "modified"),
+      stub(filename: "2026/08/removed.md", status: "removed")
+    ])
+    @client.expects(:compare).with(GithubDmcaSweeper::DMCA_REPOSITORY, "base-sha", "head-sha").returns(comparison)
+    @redis.expects(:set).with(GithubDmcaSweeper::CURSOR_KEY, "head-sha")
+
+    result = @sweeper.sweep
+
+    assert_equal 0, result[:notice_files]
+    assert_equal 0, result[:candidates]
+  end
+
+  test "uses a one week baseline on the first run" do
+    @redis.expects(:get).with(GithubDmcaSweeper::CURSOR_KEY).returns(nil)
+    expect_head
+    @client.expects(:commits)
+      .with(GithubDmcaSweeper::DMCA_REPOSITORY, has_entries(per_page: 1))
+      .returns([stub(sha: "week-old-sha")])
+    @client.expects(:compare)
+      .with(GithubDmcaSweeper::DMCA_REPOSITORY, "week-old-sha", "head-sha")
+      .returns(stub(files: []))
+    @redis.expects(:set).with(GithubDmcaSweeper::CURSOR_KEY, "head-sha")
+
+    result = @sweeper.sweep
+
+    assert_equal "head-sha", result[:head_sha]
+  end
+
+  test "does not advance the cursor when a repository check fails" do
+    create(:repository, host: @host, full_name: "Broken/Check", owner: "Broken")
+    expect_comparison("https://github.com/Broken/Check", advance_cursor: false)
+    @client.expects(:repository).with("Broken/Check").raises(Octokit::InternalServerError)
+
+    assert_raises(Octokit::InternalServerError) { @sweeper.sweep }
+  end
+
+  test "refuses a comparison at the GitHub file limit" do
+    @redis.expects(:get).with(GithubDmcaSweeper::CURSOR_KEY).returns("base-sha")
+    expect_head
+    files = Array.new(GithubDmcaSweeper::MAX_COMPARISON_FILES) do |index|
+      stub(filename: "2026/08/notice-#{index}.md", status: "added")
+    end
+    @client.expects(:compare)
+      .with(GithubDmcaSweeper::DMCA_REPOSITORY, "base-sha", "head-sha")
+      .returns(stub(files: files))
+
+    error = assert_raises(RuntimeError) { @sweeper.sweep }
+    assert_includes error.message, "300-file limit"
+  end
+
+  def expect_comparison(content, advance_cursor: true)
+    @redis.expects(:get).with(GithubDmcaSweeper::CURSOR_KEY).returns("base-sha")
+    expect_head
+    file = stub(filename: "2026/08/notice.md", status: "added")
+    @client.expects(:compare)
+      .with(GithubDmcaSweeper::DMCA_REPOSITORY, "base-sha", "head-sha")
+      .returns(stub(files: [file]))
+    @client.expects(:contents)
+      .with(GithubDmcaSweeper::DMCA_REPOSITORY, path: file.filename, ref: "head-sha")
+      .returns(stub(content: Base64.strict_encode64(content)))
+    if advance_cursor
+      @redis.expects(:set).with(GithubDmcaSweeper::CURSOR_KEY, "head-sha")
+    end
+  end
+
+  def expect_head
+    @client.expects(:repository)
+      .with(GithubDmcaSweeper::DMCA_REPOSITORY)
+      .returns(stub(default_branch: "master"))
+    reference = stub(object: stub(sha: "head-sha"))
+    @client.expects(:ref)
+      .with(GithubDmcaSweeper::DMCA_REPOSITORY, "heads/master")
+      .returns(reference)
+  end
+end

--- a/test/tasks/takedown_rake_test.rb
+++ b/test/tasks/takedown_rake_test.rb
@@ -50,4 +50,16 @@ class TakedownRakeTest < ActiveSupport::TestCase
       capture_io { Rake::Task["takedown:hide_user"].execute }
     end
   end
+
+  test "sweep_github_dmca runs the sweeper under a cron lock" do
+    result = {notice_files: 2, candidates: 4, indexed: 3, removed: 1}
+    sweeper = mock("github dmca sweeper")
+    GithubDmcaSweeper.expects(:new).returns(sweeper)
+    sweeper.expects(:sweep).returns(result)
+    CronLock.expects(:acquire).with("takedown:sweep_github_dmca", ttl: 1.hour).yields
+
+    output, = capture_io { Rake::Task["takedown:sweep_github_dmca"].execute }
+
+    assert_includes output, "notices=2 candidates=4 indexed=3 removed=1"
+  end
 end


### PR DESCRIPTION
Adds a weekly task that removes indexed repositories returning 451 from new GitHub DMCA notices.