### PR TITLE
Avoid exhausting GitHub API tokens

### DIFF
--- a/app/models/hosts/github.rb
+++ b/app/models/hosts/github.rb
@@ -34,7 +34,7 @@ module Hosts
     end
 
     def fetch_random_token
-      REDIS.srandmember(token_set_key)
+      GithubTokenPool.new.fetch(list_tokens)
     end
 
     def add_tokens(tokens)

--- a/app/services/github_token_pool.rb
+++ b/app/services/github_token_pool.rb
@@ -1,0 +1,108 @@
+require "digest"
+
+class GithubRateLimitUnavailable < StandardError
+  attr_reader :retry_after
+
+  def initialize(retry_after)
+    @retry_after = retry_after
+    super("All GitHub tokens are inside the rate limit buffer; retry in #{retry_after} seconds")
+  end
+end
+
+class GithubTokenPool
+  DEFAULT_BUFFER = 100
+  DEFAULT_SECONDARY_PAUSE = 60
+  GLOBAL_PAUSE_KEY = "github_rate_limit:secondary"
+
+  def initialize(redis: REDIS, buffer: ENV.fetch("GITHUB_RATE_LIMIT_BUFFER", DEFAULT_BUFFER).to_i, now: -> { Time.now.to_i })
+    @redis = redis
+    @buffer = buffer
+    @now = now
+  end
+
+  def fetch(tokens)
+    return if tokens.empty?
+
+    raise GithubRateLimitUnavailable.new(global_retry_after) if @redis.exists?(GLOBAL_PAUSE_KEY)
+
+    keys = tokens.map { |token| token_pause_key(token) }
+    available_tokens = tokens.zip(@redis.mget(*keys)).filter_map do |token, paused|
+      token unless paused
+    end
+    return available_tokens.sample if available_tokens.any?
+
+    retry_after = keys.filter_map { |key| positive_ttl(key) }.min || DEFAULT_SECONDARY_PAUSE
+    raise GithubRateLimitUnavailable.new(retry_after)
+  end
+
+  def record_response(request_headers:, response_headers:, status:, body:)
+    token = access_token(request_headers)
+    return unless token
+
+    if secondary_limit?(status, body)
+      pause_globally(retry_after(response_headers))
+      return
+    end
+
+    remaining = header(response_headers, "x-ratelimit-remaining")
+    return unless remaining && remaining.to_i <= @buffer
+
+    reset_at = header(response_headers, "x-ratelimit-reset").to_i
+    pause_token(token, [reset_at - @now.call, 1].max)
+  end
+
+  def token_pause_key(token)
+    "github_rate_limit:token:#{Digest::SHA256.hexdigest(token)}"
+  end
+
+  def pause_token(token, seconds)
+    @redis.set(token_pause_key(token), "1", ex: seconds)
+  end
+
+  def pause_globally(seconds)
+    @redis.set(GLOBAL_PAUSE_KEY, "1", ex: seconds)
+  end
+
+  def access_token(headers)
+    authorization = header(headers, "authorization").to_s
+    authorization.sub(/\A(?:Bearer|token)\s+/i, "").presence
+  end
+
+  def secondary_limit?(status, body)
+    [403, 429].include?(status.to_i) && body.to_s.match?(/secondary rate limit/i)
+  end
+
+  def retry_after(headers)
+    value = header(headers, "retry-after").to_i
+    value.positive? ? value : DEFAULT_SECONDARY_PAUSE
+  end
+
+  def header(headers, name)
+    headers[name] || headers[name.downcase] || headers[name.split("-").map(&:capitalize).join("-")]
+  end
+
+  def global_retry_after
+    positive_ttl(GLOBAL_PAUSE_KEY) || DEFAULT_SECONDARY_PAUSE
+  end
+
+  def positive_ttl(key)
+    ttl = @redis.ttl(key)
+    ttl if ttl.positive?
+  end
+end
+
+class GithubRateLimitMiddleware < Faraday::Middleware
+  def initialize(app, pool: GithubTokenPool.new)
+    super(app)
+    @pool = pool
+  end
+
+  def on_complete(env)
+    @pool.record_response(
+      request_headers: env.request_headers,
+      response_headers: env.response_headers,
+      status: env.status,
+      body: env.body
+    )
+  end
+end

--- a/app/services/github_token_pool.rb
+++ b/app/services/github_token_pool.rb
@@ -44,10 +44,11 @@ class GithubTokenPool
       return
     end
 
-    remaining = header(response_headers, "x-ratelimit-remaining")
+    remaining = response_headers["x-ratelimit-remaining"]
     return unless remaining && remaining.to_i <= @buffer
+    return if response_headers["x-ratelimit-limit"].to_i <= @buffer
 
-    reset_at = header(response_headers, "x-ratelimit-reset").to_i
+    reset_at = response_headers["x-ratelimit-reset"].to_i
     pause_token(token, [reset_at - @now.call, 1].max)
   end
 
@@ -64,8 +65,7 @@ class GithubTokenPool
   end
 
   def access_token(headers)
-    authorization = header(headers, "authorization").to_s
-    authorization.sub(/\A(?:Bearer|token)\s+/i, "").presence
+    headers["authorization"].to_s.sub(/\A(?:Bearer|token)\s+/i, "").presence
   end
 
   def secondary_limit?(status, body)
@@ -73,12 +73,8 @@ class GithubTokenPool
   end
 
   def retry_after(headers)
-    value = header(headers, "retry-after").to_i
+    value = headers["retry-after"].to_i
     value.positive? ? value : DEFAULT_SECONDARY_PAUSE
-  end
-
-  def header(headers, name)
-    headers[name] || headers[name.downcase] || headers[name.split("-").map(&:capitalize).join("-")]
   end
 
   def global_retry_after

--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -23,3 +23,4 @@ production:
     - Gitlab::Error::ServiceUnavailable
     - Faraday::FollowRedirects::RedirectLimitReached
     - Octokit::Unauthorized
+    - GithubRateLimitUnavailable

--- a/config/initializers/faraday.rb
+++ b/config/initializers/faraday.rb
@@ -1,3 +1,5 @@
+require Rails.root.join("app/services/github_token_pool")
+
 Faraday.default_adapter = :net_http_persistent
 Faraday.default_connection_options = {
   headers: {
@@ -11,5 +13,6 @@ Octokit.middleware = Faraday::RackBuilder.new do |builder|
   builder.request :instrumentation
   builder.request :retry
   builder.request :retry, max: 5, interval: 0.05, backoff_factor: 2, exceptions: [Faraday::ConnectionFailed, Faraday::TimeoutError]
+  builder.use GithubRateLimitMiddleware
   builder.adapter Faraday.default_adapter, accept_encoding: "gzip"
 end

--- a/env.example
+++ b/env.example
@@ -7,3 +7,4 @@ POSTGRES_PORT=5432
 # TIMELINE_DOMAIN= # default: https://timeline.ecosyste.ms
 # COMMITS_DOMAIN= # default: https://commits.ecosyste.ms
 # PACKAGES_DOMAIN= # default: https://packages.ecosyste.ms
+# GITHUB_RATE_LIMIT_BUFFER= # default: 100

--- a/test/services/github_token_pool_test.rb
+++ b/test/services/github_token_pool_test.rb
@@ -6,6 +6,10 @@ class GithubTokenPoolTest < ActiveSupport::TestCase
     @pool = GithubTokenPool.new(redis: @redis, buffer: 100, now: -> { 1_000 })
   end
 
+  def headers(hash)
+    Faraday::Utils::Headers.new(hash)
+  end
+
   test "returns nil when there are no tokens" do
     assert_nil @pool.fetch([])
   end
@@ -46,8 +50,8 @@ class GithubTokenPoolTest < ActiveSupport::TestCase
     @redis.expects(:set).with(key, "1", ex: 200)
 
     @pool.record_response(
-      request_headers: {"Authorization" => "token token"},
-      response_headers: {"x-ratelimit-remaining" => "100", "x-ratelimit-reset" => "1200"},
+      request_headers: headers("Authorization" => "token token"),
+      response_headers: headers("X-RateLimit-Limit" => "5000", "X-RateLimit-Remaining" => "100", "X-RateLimit-Reset" => "1200"),
       status: 200,
       body: ""
     )
@@ -57,8 +61,19 @@ class GithubTokenPoolTest < ActiveSupport::TestCase
     @redis.expects(:set).never
 
     @pool.record_response(
-      request_headers: {"Authorization" => "token token"},
-      response_headers: {"x-ratelimit-remaining" => "101", "x-ratelimit-reset" => "1200"},
+      request_headers: headers("Authorization" => "token token"),
+      response_headers: headers("X-RateLimit-Limit" => "5000", "X-RateLimit-Remaining" => "101", "X-RateLimit-Reset" => "1200"),
+      status: 200,
+      body: ""
+    )
+  end
+
+  test "ignores rate limit resources whose limit is below the buffer" do
+    @redis.expects(:set).never
+
+    @pool.record_response(
+      request_headers: headers("Authorization" => "token token"),
+      response_headers: headers("X-RateLimit-Limit" => "30", "X-RateLimit-Remaining" => "29", "X-RateLimit-Reset" => "1200"),
       status: 200,
       body: ""
     )
@@ -68,8 +83,8 @@ class GithubTokenPoolTest < ActiveSupport::TestCase
     @redis.expects(:set).with(GithubTokenPool::GLOBAL_PAUSE_KEY, "1", ex: 90)
 
     @pool.record_response(
-      request_headers: {"Authorization" => "Bearer token"},
-      response_headers: {"retry-after" => "90", "x-ratelimit-remaining" => "4000"},
+      request_headers: headers("Authorization" => "Bearer token"),
+      response_headers: headers("Retry-After" => "90", "X-RateLimit-Remaining" => "4000"),
       status: 429,
       body: '{"message":"You have exceeded a secondary rate limit."}'
     )
@@ -79,8 +94,8 @@ class GithubTokenPoolTest < ActiveSupport::TestCase
     @redis.expects(:set).with(GithubTokenPool::GLOBAL_PAUSE_KEY, "1", ex: 60)
 
     @pool.record_response(
-      request_headers: {"Authorization" => "token token"},
-      response_headers: {},
+      request_headers: headers("Authorization" => "token token"),
+      response_headers: headers({}),
       status: 403,
       body: '{"message":"You have exceeded a secondary rate limit."}'
     )

--- a/test/services/github_token_pool_test.rb
+++ b/test/services/github_token_pool_test.rb
@@ -1,0 +1,107 @@
+require "test_helper"
+
+class GithubTokenPoolTest < ActiveSupport::TestCase
+  setup do
+    @redis = mock("redis")
+    @pool = GithubTokenPool.new(redis: @redis, buffer: 100, now: -> { 1_000 })
+  end
+
+  test "returns nil when there are no tokens" do
+    assert_nil @pool.fetch([])
+  end
+
+  test "selects from tokens that are not paused" do
+    tokens = ["paused-token", "available-token"]
+    keys = tokens.map { |token| @pool.token_pause_key(token) }
+    @redis.expects(:exists?).with(GithubTokenPool::GLOBAL_PAUSE_KEY).returns(false)
+    @redis.expects(:mget).with(*keys).returns(["1", nil])
+
+    assert_equal "available-token", @pool.fetch(tokens)
+  end
+
+  test "raises with the shortest retry time when every token is paused" do
+    tokens = ["first-token", "second-token"]
+    keys = tokens.map { |token| @pool.token_pause_key(token) }
+    @redis.expects(:exists?).with(GithubTokenPool::GLOBAL_PAUSE_KEY).returns(false)
+    @redis.expects(:mget).with(*keys).returns(["1", "1"])
+    @redis.expects(:ttl).with(keys.first).returns(45)
+    @redis.expects(:ttl).with(keys.second).returns(20)
+
+    error = assert_raises(GithubRateLimitUnavailable) { @pool.fetch(tokens) }
+
+    assert_equal 20, error.retry_after
+  end
+
+  test "raises while the whole pool is paused" do
+    @redis.expects(:exists?).with(GithubTokenPool::GLOBAL_PAUSE_KEY).returns(true)
+    @redis.expects(:ttl).with(GithubTokenPool::GLOBAL_PAUSE_KEY).returns(30)
+
+    error = assert_raises(GithubRateLimitUnavailable) { @pool.fetch(["token"]) }
+
+    assert_equal 30, error.retry_after
+  end
+
+  test "pauses a token when its remaining quota reaches the buffer" do
+    key = @pool.token_pause_key("token")
+    @redis.expects(:set).with(key, "1", ex: 200)
+
+    @pool.record_response(
+      request_headers: {"Authorization" => "token token"},
+      response_headers: {"x-ratelimit-remaining" => "100", "x-ratelimit-reset" => "1200"},
+      status: 200,
+      body: ""
+    )
+  end
+
+  test "leaves a token available while its remaining quota is above the buffer" do
+    @redis.expects(:set).never
+
+    @pool.record_response(
+      request_headers: {"Authorization" => "token token"},
+      response_headers: {"x-ratelimit-remaining" => "101", "x-ratelimit-reset" => "1200"},
+      status: 200,
+      body: ""
+    )
+  end
+
+  test "pauses the whole pool for a secondary limit response" do
+    @redis.expects(:set).with(GithubTokenPool::GLOBAL_PAUSE_KEY, "1", ex: 90)
+
+    @pool.record_response(
+      request_headers: {"Authorization" => "Bearer token"},
+      response_headers: {"retry-after" => "90", "x-ratelimit-remaining" => "4000"},
+      status: 429,
+      body: '{"message":"You have exceeded a secondary rate limit."}'
+    )
+  end
+
+  test "uses a one minute pause when a secondary limit has no retry header" do
+    @redis.expects(:set).with(GithubTokenPool::GLOBAL_PAUSE_KEY, "1", ex: 60)
+
+    @pool.record_response(
+      request_headers: {"Authorization" => "token token"},
+      response_headers: {},
+      status: 403,
+      body: '{"message":"You have exceeded a secondary rate limit."}'
+    )
+  end
+
+  test "middleware records completed responses" do
+    pool = mock("pool")
+    middleware = GithubRateLimitMiddleware.new(mock("app"), pool: pool)
+    env = OpenStruct.new(
+      request_headers: {"Authorization" => "token token"},
+      response_headers: {"x-ratelimit-remaining" => "99"},
+      status: 200,
+      body: "{}"
+    )
+    pool.expects(:record_response).with(
+      request_headers: env.request_headers,
+      response_headers: env.response_headers,
+      status: env.status,
+      body: env.body
+    )
+
+    middleware.on_complete(env)
+  end
+end


### PR DESCRIPTION
Stop selecting GitHub API tokens once response headers show that their remaining quota has reached a configurable buffer. Store token pauses in Redis so workers share the same state, and briefly pause the pool after a secondary rate limit response.