### PR TITLE
Honour retry_after when the GitHub token pool is unavailable

### DIFF
--- a/app/sidekiq/download_tags_worker.rb
+++ b/app/sidekiq/download_tags_worker.rb
@@ -1,5 +1,6 @@
 class DownloadTagsWorker
   include Sidekiq::Worker
+  include GithubRateLimitRetry
   sidekiq_options queue: 'tags', lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(repository_id)

--- a/app/sidekiq/github_rate_limit_retry.rb
+++ b/app/sidekiq/github_rate_limit_retry.rb
@@ -1,0 +1,11 @@
+module GithubRateLimitRetry
+  extend ActiveSupport::Concern
+
+  JITTER = 30
+
+  included do
+    sidekiq_retry_in do |_count, exception|
+      exception.retry_after + rand(JITTER) if exception.is_a?(GithubRateLimitUnavailable)
+    end
+  end
+end

--- a/app/sidekiq/package_usage_sync_worker.rb
+++ b/app/sidekiq/package_usage_sync_worker.rb
@@ -1,5 +1,6 @@
 class PackageUsageSyncWorker
   include Sidekiq::Worker
+  include GithubRateLimitRetry
   sidekiq_options lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(package_usage_id)

--- a/app/sidekiq/parse_dependencies_worker.rb
+++ b/app/sidekiq/parse_dependencies_worker.rb
@@ -1,5 +1,6 @@
 class ParseDependenciesWorker
   include Sidekiq::Worker
+  include GithubRateLimitRetry
   sidekiq_options queue: 'dependencies', lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(repository_id)

--- a/app/sidekiq/parse_tag_dependencies_worker.rb
+++ b/app/sidekiq/parse_tag_dependencies_worker.rb
@@ -1,5 +1,6 @@
 class ParseTagDependenciesWorker
   include Sidekiq::Worker
+  include GithubRateLimitRetry
   sidekiq_options queue: 'dependencies', lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(tag_id)

--- a/app/sidekiq/ping_owner_worker.rb
+++ b/app/sidekiq/ping_owner_worker.rb
@@ -1,5 +1,6 @@
 class PingOwnerWorker
   include Sidekiq::Worker
+  include GithubRateLimitRetry
   sidekiq_options queue: :ping, lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(host_name, full_name)

--- a/app/sidekiq/ping_packages_worker.rb
+++ b/app/sidekiq/ping_packages_worker.rb
@@ -1,5 +1,6 @@
 class PingPackagesWorker
   include Sidekiq::Worker
+  include GithubRateLimitRetry
   sidekiq_options queue: :default, lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(repo_id)

--- a/app/sidekiq/ping_worker.rb
+++ b/app/sidekiq/ping_worker.rb
@@ -1,5 +1,6 @@
 class PingWorker
   include Sidekiq::Worker
+  include GithubRateLimitRetry
   sidekiq_options queue: :ping, lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(host_name, full_name, force = false)

--- a/app/sidekiq/repository_usage_worker.rb
+++ b/app/sidekiq/repository_usage_worker.rb
@@ -1,5 +1,6 @@
 class RepositoryUsageWorker
   include Sidekiq::Worker
+  include GithubRateLimitRetry
   sidekiq_options lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(repository_id)

--- a/app/sidekiq/sync_commit_stats_worker.rb
+++ b/app/sidekiq/sync_commit_stats_worker.rb
@@ -1,5 +1,6 @@
 class SyncCommitStatsWorker
   include Sidekiq::Worker
+  include GithubRateLimitRetry
   sidekiq_options lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(repository_id)

--- a/app/sidekiq/sync_extra_details_worker.rb
+++ b/app/sidekiq/sync_extra_details_worker.rb
@@ -1,5 +1,6 @@
 class SyncExtraDetailsWorker
   include Sidekiq::Worker
+  include GithubRateLimitRetry
   sidekiq_options queue: 'extra', lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(repository_id)

--- a/app/sidekiq/sync_inactive_repository_worker.rb
+++ b/app/sidekiq/sync_inactive_repository_worker.rb
@@ -1,5 +1,6 @@
 class SyncInactiveRepositoryWorker
   include Sidekiq::Worker
+  include GithubRateLimitRetry
   sidekiq_options lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(repository_id)

--- a/app/sidekiq/sync_owner_worker.rb
+++ b/app/sidekiq/sync_owner_worker.rb
@@ -1,5 +1,6 @@
 class SyncOwnerWorker
   include Sidekiq::Worker
+  include GithubRateLimitRetry
   sidekiq_options lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(host_id, login)

--- a/app/sidekiq/sync_repository_worker.rb
+++ b/app/sidekiq/sync_repository_worker.rb
@@ -1,5 +1,6 @@
 class SyncRepositoryWorker
   include Sidekiq::Worker
+  include GithubRateLimitRetry
   sidekiq_options lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(host_id, full_name)

--- a/app/sidekiq/sync_scorecard_worker.rb
+++ b/app/sidekiq/sync_scorecard_worker.rb
@@ -1,5 +1,6 @@
 class SyncScorecardWorker
   include Sidekiq::Worker
+  include GithubRateLimitRetry
   sidekiq_options lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(repo_id)

--- a/app/sidekiq/update_metadata_files_worker.rb
+++ b/app/sidekiq/update_metadata_files_worker.rb
@@ -1,5 +1,6 @@
 class UpdateMetadataFilesWorker
   include Sidekiq::Worker
+  include GithubRateLimitRetry
   sidekiq_options lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(repo_id)

--- a/app/sidekiq/update_repository_worker.rb
+++ b/app/sidekiq/update_repository_worker.rb
@@ -1,5 +1,6 @@
 class UpdateRepositoryWorker
   include Sidekiq::Worker
+  include GithubRateLimitRetry
   sidekiq_options lock: :until_executed, lock_expiration: 1.day.to_i
 
   def perform(repo_id, force = false)

--- a/test/workers/github_rate_limit_retry_test.rb
+++ b/test/workers/github_rate_limit_retry_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class GithubRateLimitRetryTest < ActiveSupport::TestCase
+  should 'delay by retry_after plus jitter when the token pool is unavailable' do
+    exception = GithubRateLimitUnavailable.new(45)
+
+    delay = SyncRepositoryWorker.sidekiq_retry_in_block.call(0, exception)
+
+    assert_includes 45...(45 + GithubRateLimitRetry::JITTER), delay
+  end
+
+  should 'fall back to default backoff for other errors' do
+    assert_nil SyncRepositoryWorker.sidekiq_retry_in_block.call(0, StandardError.new)
+  end
+
+  should 'be included in every worker' do
+    workers = ObjectSpace.each_object(Class).select { |c| c < Sidekiq::Worker }
+
+    assert workers.all? { |w| w < GithubRateLimitRetry }
+  end
+end


### PR DESCRIPTION
When `GithubTokenPool` raises `GithubRateLimitUnavailable` every in-flight job that needs a GitHub client fails at once. Without a custom retry schedule they land on Sidekiq's default backoff and burn early retries while the pool is still paused, and once it clears they all retry within the same few seconds.

Add a `GithubRateLimitRetry` concern that sets `sidekiq_retry_in` to the exception's `retry_after` plus up to 30s of jitter, and returns nil for any other exception so default backoff still applies. Included in every worker so nobody has to remember to add it when a worker gains a GitHub call.

Stacked on #1185.