### PR TITLE
Restrict sort parameters to allowlisted columns

### DIFF
--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -9,14 +9,7 @@ class Api::V1::OwnersController < Api::V1::ApplicationController
     scope = scope.kind(params[:kind]) if params[:kind].present?
     scope = scope.has_sponsors_listing if params[:has_sponsors_listing].present?
 
-    if params[:sort].present? || params[:order].present?
-      sort = params[:sort] || 'last_synced_at'
-      order = params[:order] || 'desc'
-      sort_options = sort.split(',').zip(order.split(',')).to_h
-      scope = scope.order(sort_options)
-    else
-      scope = scope.order('last_synced_at DESC')
-    end
+    scope = scope.order(*sanitize_orders(Owner.sortable_columns, default: 'last_synced_at'))
 
     @pagy, @owners = pagy_countless(scope)
     fresh_when @owners, public: true
@@ -43,14 +36,7 @@ class Api::V1::OwnersController < Api::V1::ApplicationController
     scope = scope.forked(params[:fork]) if params[:fork].present?
     scope = scope.archived(params[:archived]) if params[:archived].present?
 
-    if params[:sort].present? || params[:order].present?
-      sort = params[:sort] || 'last_synced_at'
-      order = params[:order] || 'desc'
-      sort_options = sort.split(',').zip(order.split(',')).to_h
-      scope = scope.order(sort_options)
-    else
-      scope = scope.order('last_synced_at DESC')
-    end
+    scope = scope.order(*sanitize_orders(Repository.sortable_columns, default: 'last_synced_at'))
 
     @pagy, @repositories = pagy_countless(scope.includes(:host, :scorecard))
     if stale?(@repositories, public: true)

--- a/app/controllers/api/v1/releases_controller.rb
+++ b/app/controllers/api/v1/releases_controller.rb
@@ -14,14 +14,7 @@ class Api::V1::ReleasesController < Api::V1::ApplicationController
 
       scope = @repository.releases
 
-      if params[:sort].present? || params[:order].present?
-        sort = params[:sort] || 'published_at'
-        order = params[:order] || 'desc'
-        sort_options = sort.split(',').zip(order.split(',')).to_h
-        scope = scope.order(sort_options)
-      else
-        scope = scope.order('published_at DESC')
-      end
+      scope = scope.order(*sanitize_orders(Release.sortable_columns, default: 'published_at'))
 
       @pagy, @releases = pagy_countless(scope)
       fresh_when @releases, public: true

--- a/app/controllers/api/v1/repositories_controller.rb
+++ b/app/controllers/api/v1/repositories_controller.rb
@@ -15,10 +15,7 @@ class Api::V1::RepositoriesController < Api::V1::ApplicationController
     scope = scope.forked(params[:fork]) if params[:fork].present?
     scope = scope.archived(params[:archived]) if params[:archived].present?
 
-    sort = params[:sort] || 'id'
-    order = params[:order] || 'desc'
-    sort_options = sort.split(',').zip(order.split(',')).to_h
-    scope = scope.order(sort_options)
+    scope = scope.order(*sanitize_orders(Repository.host_sortable_columns, default: 'id'))
 
     @pagy, @repositories = pagy_countless(scope.includes(:host, :scorecard))
     fresh_when @repositories, public: true
@@ -37,10 +34,7 @@ class Api::V1::RepositoriesController < Api::V1::ApplicationController
     scope = scope.forked(params[:fork]) if params[:fork].present?
     scope = scope.archived(params[:archived]) if params[:archived].present?
 
-    sort = params[:sort] || 'id'
-    order = params[:order] || 'desc'
-    sort_options = sort.split(',').zip(order.split(',')).to_h
-    scope = scope.order(sort_options)
+    scope = scope.order(*sanitize_orders(Repository.host_sortable_columns, default: 'id'))
 
     @pagy, @repositories = pagy_countless(scope, limit_max: 10000)
     if stale?(@repositories, public: true)

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -14,14 +14,7 @@ class Api::V1::TagsController < Api::V1::ApplicationController
 
       scope = @repository.tags
 
-      if params[:sort].present? || params[:order].present?
-        sort = params[:sort] || 'published_at'
-        order = params[:order] || 'desc'
-        sort_options = sort.split(',').zip(order.split(',')).to_h
-        scope = scope.order(sort_options)
-      else
-        scope = scope.order('published_at DESC')
-      end
+      scope = scope.order(*sanitize_orders(Tag.sortable_columns, default: 'published_at'))
 
       @pagy, @tags = pagy_countless(scope)
       fresh_when @tags, public: true

--- a/app/controllers/api/v1/usage_controller.rb
+++ b/app/controllers/api/v1/usage_controller.rb
@@ -21,10 +21,7 @@ class Api::V1::UsageController < Api::V1::ApplicationController
 
     scope = @usage.repositories.includes(:host, :scorecard)
 
-    sort = params[:sort] || 'id'
-    order = params[:order] || 'asc'
-    sort_options = sort.split(',').zip(order.split(',')).to_h
-    scope = scope.order(sort_options)
+    scope = scope.order(*sanitize_orders(Repository.sortable_columns, default: 'id', default_order: 'asc'))
 
     if params[:after_id].present?
       scope = scope.where('repositories.id > ?', params[:after_id])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,10 +37,28 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def sanitize_sort(allowed_columns, default: 'updated_at')
-    sort_param = params[:sort].presence || default
+  def sanitize_sort(allowed_columns, default: 'updated_at', sort_param: params[:sort].presence)
+    sort_param ||= default
     sql = allowed_columns[sort_param] || allowed_columns[default] || default
     Arel.sql(sql)
+  end
+
+  def sanitize_orders(allowed_columns, default: 'updated_at', default_order: 'desc')
+    sort_params = params[:sort].present? ? params[:sort].to_s.split(',') : [default]
+    order_params = params[:order].present? ? params[:order].to_s.split(',') : [default_order]
+
+    orders = sort_params.each_with_index.filter_map do |sort_param, index|
+      next unless allowed_columns.key?(sort_param)
+
+      order = order_params[index].to_s.downcase
+      next unless %w[asc desc].include?(order)
+
+      sanitize_sort(allowed_columns, default: default, sort_param: sort_param).public_send(order)
+    end
+
+    return orders if orders.any?
+
+    [sanitize_sort(allowed_columns, default: default, sort_param: default).public_send(default_order)]
   end
 
   def related_topics_for_scope(scope, exclude_topic)

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -15,7 +15,7 @@ class HostsController < ApplicationController
     scope = @host.repositories
 
     if params[:sort].present?
-      sort = sanitize_sort(Repository.sortable_columns, default: 'id')
+      sort = sanitize_sort(Repository.host_sortable_columns, default: 'id')
       if params[:order] == 'asc'
         scope = scope.order(sort.asc.nulls_last)
       else

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -13,6 +13,22 @@ class Owner < ApplicationRecord
   enum :kind, {:user=>"user", :organization=>"organization"}
 
   scope :has_sponsors_listing, -> { where("metadata->>'has_sponsors_listing' = 'true'") }
+
+  def self.sortable_columns
+    {
+      'id' => 'owners.id',
+      'login' => 'owners.login',
+      'name' => 'owners.name',
+      'kind' => 'owners.kind',
+      'followers' => 'owners.followers',
+      'following' => 'owners.following',
+      'repositories_count' => 'owners.repositories_count',
+      'total_stars' => 'owners.total_stars',
+      'created_at' => 'owners.created_at',
+      'updated_at' => 'owners.updated_at',
+      'last_synced_at' => 'owners.last_synced_at',
+    }
+  end
   
   def self.sync_least_recently_synced
     Owner.order('last_synced_at asc nulls first').includes(:host).limit(2500).each(&:sync_async)

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -1,6 +1,18 @@
 class Release < ApplicationRecord
   belongs_to :repository
 
+  def self.sortable_columns
+    {
+      'id' => 'releases.id',
+      'name' => 'releases.name',
+      'tag_name' => 'releases.tag_name',
+      'published_at' => 'releases.published_at',
+      'created_at' => 'releases.created_at',
+      'updated_at' => 'releases.updated_at',
+      'last_synced_at' => 'releases.last_synced_at',
+    }
+  end
+
   def self.backfill_immutability(repository_names:, block_size: 1_000, after_name: nil)
     raise ArgumentError, 'block_size must be greater than zero' unless block_size.positive?
 

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -41,18 +41,26 @@ class Repository < ApplicationRecord
 
   def self.sortable_columns
     {
-      'id' => 'id',
-      'updated_at' => 'updated_at',
-      'created_at' => 'created_at',
-      'stargazers_count' => 'stargazers_count',
-      'forks_count' => 'forks_count',
-      'open_issues_count' => 'open_issues_count',
-      'subscribers_count' => 'subscribers_count',
-      'size' => 'size',
-      'pushed_at' => 'pushed_at',
-      'full_name' => 'full_name',
-      'language' => 'language',
-      'tags_count' => 'tags_count',
+      'id' => 'repositories.id',
+      'updated_at' => 'repositories.updated_at',
+      'created_at' => 'repositories.created_at',
+      'last_synced_at' => 'repositories.last_synced_at',
+      'stargazers_count' => 'repositories.stargazers_count',
+      'forks_count' => 'repositories.forks_count',
+      'open_issues_count' => 'repositories.open_issues_count',
+      'subscribers_count' => 'repositories.subscribers_count',
+      'size' => 'repositories.size',
+      'pushed_at' => 'repositories.pushed_at',
+      'full_name' => 'repositories.full_name',
+      'language' => 'repositories.language',
+      'tags_count' => 'repositories.tags_count',
+    }
+  end
+
+  def self.host_sortable_columns
+    {
+      'id' => 'repositories.id',
+      'full_name' => 'lower(repositories.full_name)',
     }
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -11,6 +11,18 @@ class Tag < ApplicationRecord
 
   has_many :manifests, dependent: :destroy
 
+  def self.sortable_columns
+    {
+      'id' => 'tags.id',
+      'name' => 'tags.name',
+      'sha' => 'tags.sha',
+      'kind' => 'tags.kind',
+      'published_at' => 'tags.published_at',
+      'created_at' => 'tags.created_at',
+      'updated_at' => 'tags.updated_at',
+    }
+  end
+
   def to_s
     name
   end

--- a/test/controllers/api/v1/owners_controller_test.rb
+++ b/test/controllers/api/v1/owners_controller_test.rb
@@ -20,6 +20,18 @@ class ApiV1OwnersControllerTest < ActionDispatch::IntegrationTest
     assert_equal actual_response.length, 2
   end
 
+  test 'invalid owner sort falls back to last synced descending' do
+    @owner.update!(last_synced_at: 2.days.ago)
+    @hidden_owner.update!(last_synced_at: 1.day.ago)
+
+    get api_v1_host_owners_path(host_id: @host.name), params: { sort: 'cast(uuid as integer)' }
+    assert_response :success
+
+    actual_response = JSON.parse(@response.body)
+
+    assert_equal [@hidden_owner.login, @owner.login], actual_response.pluck('login')
+  end
+
   test 'get a owner for a host' do
     get api_v1_host_owner_path(host_id: @host.name, id: @owner.login)
     assert_response :success
@@ -43,6 +55,18 @@ class ApiV1OwnersControllerTest < ActionDispatch::IntegrationTest
     actual_response = JSON.parse(@response.body)
 
     assert_equal actual_response.length, 0
+  end
+
+  test 'invalid owner repository sort falls back to last synced descending' do
+    older_repository = create(:repository, host: @host, owner: @owner.login, last_synced_at: 2.days.ago)
+    newer_repository = create(:repository, host: @host, owner: @owner.login, last_synced_at: 1.day.ago)
+
+    get repositories_api_v1_host_owner_path(host_id: @host.name, id: @owner.login), params: { sort: 'cast(uuid as integer)' }
+    assert_response :success
+
+    actual_response = JSON.parse(@response.body)
+
+    assert_equal [newer_repository.id, older_repository.id], actual_response.pluck('id')
   end
 
   test 'list repositories for a hidden owner returns 404' do

--- a/test/controllers/api/v1/releases_controller_test.rb
+++ b/test/controllers/api/v1/releases_controller_test.rb
@@ -48,6 +48,16 @@ class Api::V1::ReleasesControllerTest < ActionDispatch::IntegrationTest
     assert_equal ['v2.0.0', 'v1.0.0'], release_tags
   end
 
+  test "invalid release sort falls back to published_at descending" do
+    get api_v1_host_repository_releases_path(@host.name, @repository.full_name), params: { sort: 'cast(uuid as integer)' }
+    assert_response :success
+
+    data = JSON.parse(@response.body)
+    release_tags = data.map { |release| release['tag_name'] }
+
+    assert_equal ['v2.0.0', 'v1.0.0'], release_tags
+  end
+
   test "should show individual release" do
     get api_v1_host_repository_release_path(@host.name, @repository.full_name, @release_v1.tag_name)
     assert_response :success

--- a/test/controllers/api/v1/repositories_controller_test.rb
+++ b/test/controllers/api/v1/repositories_controller_test.rb
@@ -43,6 +43,52 @@ class ApiV1RepositoriesControllerTest < ActionDispatch::IntegrationTest
     assert_equal actual_response.length, 3
   end
 
+  test 'invalid repository sort falls back to id descending' do
+    get api_v1_host_repositories_path(host_id: @host.name), params: { sort: 'cast(uuid as integer)' }
+    assert_response :success
+
+    actual_response = JSON.parse(@response.body)
+
+    assert_equal @host.repositories.order(id: :desc).pluck(:id), actual_response.pluck('id')
+  end
+
+  test 'unindexed repository sort falls back to id descending' do
+    get api_v1_host_repositories_path(host_id: @host.name), params: { sort: 'stargazers_count', order: 'desc' }
+    assert_response :success
+
+    actual_response = JSON.parse(@response.body)
+
+    assert_equal @host.repositories.order(id: :desc).pluck(:id), actual_response.pluck('id')
+  end
+
+  test 'invalid repository order falls back to id descending' do
+    get api_v1_host_repositories_path(host_id: @host.name), params: { sort: 'id', order: '1' }
+    assert_response :success
+
+    actual_response = JSON.parse(@response.body)
+
+    assert_equal @host.repositories.order(id: :desc).pluck(:id), actual_response.pluck('id')
+  end
+
+  test 'repository sort allows case insensitive full name ordering' do
+    get api_v1_host_repositories_path(host_id: @host.name), params: { sort: 'full_name', order: 'asc' }
+    assert_response :success
+
+    actual_response = JSON.parse(@response.body)
+
+    assert_equal @host.repositories.order(Arel.sql('lower(full_name) ASC')).pluck(:id), actual_response.pluck('id')
+  end
+
+  test 'repository sort allows multiple indexed columns' do
+    get api_v1_host_repositories_path(host_id: @host.name), params: { sort: 'full_name,id', order: 'asc,desc' }
+    assert_response :success
+
+    actual_response = JSON.parse(@response.body)
+    expected_ids = @host.repositories.order(Arel.sql('lower(full_name) ASC'), id: :desc).pluck(:id)
+
+    assert_equal expected_ids, actual_response.pluck('id')
+  end
+
   test 'get repository names for a host' do
     get repository_names_api_v1_host_path(id: @host.name)
     assert_response :success
@@ -53,6 +99,15 @@ class ApiV1RepositoriesControllerTest < ActionDispatch::IntegrationTest
     assert_includes actual_response, 'testuser/awesome-project'
     assert_includes actual_response, 'testorg/enterprise-app'
     assert_includes actual_response, 'hiddenuser/secret-project'
+  end
+
+  test 'invalid repository names sort falls back to id descending' do
+    get repository_names_api_v1_host_path(id: @host.name), params: { sort: 'cast(uuid as integer)' }
+    assert_response :success
+
+    actual_response = JSON.parse(@response.body)
+
+    assert_equal @host.repositories.order(id: :desc).pluck(:full_name), actual_response
   end
 
   test 'get a repository for a host' do

--- a/test/controllers/api/v1/tags_controller_test.rb
+++ b/test/controllers/api/v1/tags_controller_test.rb
@@ -16,4 +16,16 @@ class ApiV1TagsControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal actual_response.length, 1
   end
+
+  test 'invalid tag sort falls back to published at descending' do
+    @tag.update!(published_at: 2.days.ago)
+    newer_tag = @repository.tags.create!(name: '2.0.0', sha: 'feedface', published_at: 1.day.ago)
+
+    get api_v1_host_repository_tags_path(host_id: @host.name, repository_id: @repository.full_name), params: { sort: 'cast(uuid as integer)' }
+    assert_response :success
+
+    actual_response = JSON.parse(@response.body)
+
+    assert_equal [newer_tag.name, @tag.name], actual_response.pluck('name')
+  end
 end

--- a/test/controllers/api/v1/usage_controller_test.rb
+++ b/test/controllers/api/v1/usage_controller_test.rb
@@ -18,4 +18,17 @@ class ApiV1UsageControllerTest < ActionDispatch::IntegrationTest
     get api_v1_usage_url('npm', 'lodash')
     assert_response :success
   end
+
+  test "invalid dependent repository sort falls back to id ascending" do
+    usage = create(:package_usage, ecosystem: 'npm', name: 'lodash')
+    repositories = create_list(:repository, 2)
+    usage.repositories << repositories.reverse
+
+    get api_v1_usage_dependent_repositories_url('npm', 'lodash'), params: { sort: 'cast(uuid as integer)' }
+    assert_response :success
+
+    actual_response = JSON.parse(@response.body)
+
+    assert_equal repositories.map(&:id).sort, actual_response.pluck('id')
+  end
 end

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -162,7 +162,7 @@ class HostsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/dropdown-toggle/, response.body)
   end
 
-  test 'explicit sort param still applies nulls last' do
+  test 'unindexed sort falls back to id descending' do
     queries = []
     callback = ->(*, payload) { queries << payload[:sql] if payload[:sql].include?('repositories') }
     ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') do
@@ -170,7 +170,18 @@ class HostsControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :success
     repo_query = queries.find { |q| q =~ /ORDER BY/i }
-    assert_match(/stargazers_count DESC NULLS LAST/i, repo_query)
+    assert_match(/repositories\.id DESC NULLS LAST/i, repo_query)
+  end
+
+  test 'full name sort uses indexed case insensitive expression' do
+    queries = []
+    callback = ->(*, payload) { queries << payload[:sql] if payload[:sql].include?('repositories') }
+    ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') do
+      get host_path(id: @host.name), params: { sort: 'full_name', order: 'asc' }
+    end
+    assert_response :success
+    repo_query = queries.find { |q| q =~ /ORDER BY/i }
+    assert_match(/lower\(repositories\.full_name\) ASC NULLS LAST/i, repo_query)
   end
 
   test 'get a host with pagination parameters' do


### PR DESCRIPTION
Restricts API sort fields and directions to model allowlists. Host-wide repository lists now accept only indexed `id` and case-insensitive `full_name` sorting, while bounded owner, usage, tag, and release lists keep their supported fields. Unknown sort values and directions fall back to each endpoint default.

Closes #1183
Related to #880