### PR TITLE
Find public gitea, forgejo and gitlab instances with shodan.io

### DIFF
--- a/app/services/shodan_host_discovery.rb
+++ b/app/services/shodan_host_discovery.rb
@@ -1,3 +1,6 @@
+require 'ipaddr'
+require 'resolv'
+
 # Finds public gitea/forgejo/gitlab instances with shodan.io so they can be indexed.
 #
 # Shodan only supplies candidate domains, each candidate is then probed directly
@@ -22,7 +25,15 @@ class ShodanHostDiscovery
   TIMEOUT = 10
 
   DOMAIN = /\A[a-z0-9]([a-z0-9\-.]*[a-z0-9])?\.[a-z]{2,}\z/
-  RESERVED_DOMAIN = /\.(local|localdomain|internal|intranet|lan|home|test|invalid|example|arpa)\z/
+  RESERVED_DOMAIN = /\.(local|localhost|localdomain|internal|intranet|lan|home|test|invalid|example|arpa)\z/
+
+  # Ranges IPAddr has no predicate for: this network, shared address space and
+  # the unspecified address.
+  UNROUTABLE_RANGES = [
+    IPAddr.new('0.0.0.0/8'),
+    IPAddr.new('100.64.0.0/10'),
+    IPAddr.new('::/128')
+  ].freeze
 
   IGNORABLE_EXCEPTIONS = [
     Faraday::Error,
@@ -116,6 +127,8 @@ class ShodanHostDiscovery
   end
 
   def probe(domain)
+    return nil unless routable?(domain)
+
     url = "https://#{domain}"
     return nil unless crawlable?(url)
 
@@ -134,8 +147,9 @@ class ShodanHostDiscovery
   end
 
   # Listing projects anonymously is the thing we need from gitlab, so it doubles
-  # as the check that this is a gitlab instance worth indexing. The version api
-  # needs a token, so it is left for Host#update_version.
+  # as the check that this is a gitlab instance worth indexing. Gitlab will not
+  # report its version without a token, so it stays blank until one is
+  # configured for the host.
   def gitlab_candidate(domain, url)
     projects = get_json("#{url}/api/v4/projects", per_page: 1, simple: true)
     return nil unless projects.is_a?(Array) && projects.any?
@@ -153,11 +167,38 @@ class ShodanHostDiscovery
     body.is_a?(Hash) ? body['version'].presence : nil
   end
 
+  # Everything we ask a candidate for lives under /api, so this applies the same
+  # rules Host does before it calls an instance's api rather than only checking
+  # the root.
   def crawlable?(url)
     response = get("#{url}/robots.txt")
     return true if response.nil? || !response.success?
 
-    RobotsTxtParser.new(response.body).can_crawl?('/')
+    Host.new(robots_txt_content: response.body).can_crawl_api?(user_agent)
+  end
+
+  # Shodan hands us hostnames nobody has vetted, so a name pointing back inside
+  # our own network is dropped before anything is fetched from it.
+  def routable?(domain)
+    addresses = resolved_addresses(domain)
+    return true if addresses.empty?
+
+    addresses.none? { |address| unroutable?(address) }
+  end
+
+  # A name that will not resolve is left alone, the request itself fails soon
+  # enough.
+  def resolved_addresses(domain)
+    Resolv.getaddresses(domain).filter_map do |address|
+      IPAddr.new(address).native
+    rescue IPAddr::Error
+      nil
+    end
+  end
+
+  def unroutable?(address)
+    address.loopback? || address.private? || address.link_local? ||
+      UNROUTABLE_RANGES.any? { |range| range.include?(address) }
   end
 
   def create_host(candidate)
@@ -191,9 +232,11 @@ class ShodanHostDiscovery
     nil
   end
 
+  # Redirects are deliberately not followed. Every request made here is driven
+  # by a hostname shodan supplied, so a Location header would be an easy way to
+  # move us onto an address that was never checked.
   def connection
     @connection ||= Faraday.new do |conn|
-      conn.use Faraday::FollowRedirects::Middleware
       conn.adapter Faraday.default_adapter
     end
   end

--- a/app/services/shodan_host_discovery.rb
+++ b/app/services/shodan_host_discovery.rb
@@ -1,0 +1,204 @@
+# Finds public gitea/forgejo/gitlab instances with shodan.io so they can be indexed.
+#
+# Shodan only supplies candidate domains, each candidate is then probed directly
+# to work out what it actually runs and whether its repositories are readable
+# without an account. Instances that are already known, that block us in
+# robots.txt or that expose no public repositories are dropped.
+class ShodanHostDiscovery
+  class MissingApiKey < StandardError; end
+  class ApiError < StandardError; end
+
+  SHODAN_API_URL = 'https://api.shodan.io'
+  RESULTS_PER_PAGE = 100
+
+  QUERIES = [
+    'http.html:"Powered by Gitea"',
+    'http.html:"Powered by Forgejo"',
+    'http.title:"GitLab"'
+  ].freeze
+
+  DEFAULT_PAGES = 1
+  DEFAULT_LIMIT = 50
+  TIMEOUT = 10
+
+  DOMAIN = /\A[a-z0-9]([a-z0-9\-.]*[a-z0-9])?\.[a-z]{2,}\z/
+  RESERVED_DOMAIN = /\.(local|localdomain|internal|intranet|lan|home|test|invalid|example|arpa)\z/
+
+  IGNORABLE_EXCEPTIONS = [
+    Faraday::Error,
+    Net::OpenTimeout,
+    Net::ReadTimeout,
+    Socket::ResolutionError,
+    OpenSSL::SSL::SSLError,
+    URI::InvalidURIError
+  ].freeze
+
+  Candidate = Struct.new(:domain, :url, :kind, :version, keyword_init: true) do
+    def to_seed_line
+      %(  {name: "#{domain}", url: "#{url}", kind: "#{kind}"},)
+    end
+  end
+
+  def initialize(api_key: ENV['SHODAN_API_KEY'], queries: QUERIES, pages: DEFAULT_PAGES,
+                 limit: DEFAULT_LIMIT, create: false, output: $stdout)
+    @api_key = api_key
+    @queries = Array(queries).reject(&:blank?)
+    @pages = pages.to_i.clamp(1, 20)
+    @limit = limit.to_i.clamp(1, 1000)
+    @create = create
+    @output = output
+  end
+
+  def discover
+    raise MissingApiKey, 'SHODAN_API_KEY is not set' if @api_key.blank?
+
+    found = search_domains
+    unknown = found.reject { |domain| known_domain?(domain) }.first(@limit)
+    candidates = unknown.filter_map { |domain| probe(domain) }
+    created = @create ? candidates.filter_map { |candidate| create_host(candidate) } : []
+
+    { found: found.length, probed: unknown.length, candidates: candidates, created: created }
+  end
+
+  private
+
+  def search_domains
+    @queries.flat_map { |query| domains_for(query) }.uniq
+  end
+
+  def domains_for(query)
+    domains = []
+
+    (1..@pages).each do |page|
+      matches = Array(search(query, page)['matches'])
+      domains.concat(matches.flat_map { |match| match_domains(match) })
+      break if matches.length < RESULTS_PER_PAGE
+    end
+
+    domains
+  end
+
+  def search(query, page)
+    response = get("#{SHODAN_API_URL}/shodan/host/search", key: @api_key, query: query, page: page)
+    raise ApiError, "shodan search for #{query} failed: no response" if response.nil?
+    raise ApiError, "shodan search for #{query} failed: #{shodan_error(response)}" unless response.success?
+
+    body = parse_json(response.body)
+    raise ApiError, "shodan search for #{query} returned an unreadable response" unless body.is_a?(Hash)
+
+    body
+  end
+
+  # Shodan reports the error itself in a json body, the api key is never echoed
+  # back but the raw body is not repeated here either in case it ever is.
+  def shodan_error(response)
+    body = parse_json(response.body)
+    message = body['error'] if body.is_a?(Hash)
+    "HTTP #{response.status}#{": #{message}" if message.present?}"
+  end
+
+  def match_domains(match)
+    names = Array(match['hostnames']) + [match.dig('http', 'host')]
+    names.filter_map { |name| normalize_domain(name) }.uniq
+  end
+
+  def normalize_domain(name)
+    domain = Host.normalize_domain(name)
+    return nil if domain.blank?
+    return nil unless domain.match?(DOMAIN)
+    return nil if domain.match?(RESERVED_DOMAIN)
+
+    domain
+  end
+
+  def known_domain?(domain)
+    Host.find_by_domain(domain).present?
+  end
+
+  def probe(domain)
+    url = "https://#{domain}"
+    return nil unless crawlable?(url)
+
+    gitea_candidate(domain, url) || gitlab_candidate(domain, url)
+  end
+
+  # Gitea and forgejo share the same api, only forgejo answers on its own
+  # versioned namespace.
+  def gitea_candidate(domain, url)
+    version = version_from("#{url}/api/v1/version")
+    return nil if version.blank?
+    return nil unless gitea_public_repositories?(url)
+
+    kind = version_from("#{url}/api/forgejo/v1/version").present? ? 'forgejo' : 'gitea'
+    Candidate.new(domain: domain, url: url, kind: kind, version: version)
+  end
+
+  # Listing projects anonymously is the thing we need from gitlab, so it doubles
+  # as the check that this is a gitlab instance worth indexing. The version api
+  # needs a token, so it is left for Host#update_version.
+  def gitlab_candidate(domain, url)
+    projects = get_json("#{url}/api/v4/projects", per_page: 1, simple: true)
+    return nil unless projects.is_a?(Array) && projects.any?
+
+    Candidate.new(domain: domain, url: url, kind: 'gitlab', version: nil)
+  end
+
+  def gitea_public_repositories?(url)
+    body = get_json("#{url}/api/v1/repos/search", limit: 1)
+    body.is_a?(Hash) && Array(body['data']).any?
+  end
+
+  def version_from(url)
+    body = get_json(url)
+    body.is_a?(Hash) ? body['version'].presence : nil
+  end
+
+  def crawlable?(url)
+    response = get("#{url}/robots.txt")
+    return true if response.nil? || !response.success?
+
+    RobotsTxtParser.new(response.body).can_crawl?('/')
+  end
+
+  def create_host(candidate)
+    Host.create!(name: candidate.domain, url: candidate.url, kind: candidate.kind, version: candidate.version)
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
+    @output.puts "[repos] skipping #{candidate.domain}: #{e.message}"
+    nil
+  end
+
+  def get_json(url, params = {})
+    response = get(url, params)
+    return nil if response.nil? || !response.success?
+
+    parse_json(response.body)
+  end
+
+  def get(url, params = {})
+    connection.get(url) do |req|
+      req.params.update(params.stringify_keys) if params.present?
+      req.options.timeout = TIMEOUT
+      req.options.open_timeout = TIMEOUT
+      req.headers['User-Agent'] = user_agent
+    end
+  rescue *IGNORABLE_EXCEPTIONS
+    nil
+  end
+
+  def parse_json(body)
+    JSON.parse(body.to_s)
+  rescue JSON::ParserError
+    nil
+  end
+
+  def connection
+    @connection ||= Faraday.new do |conn|
+      conn.use Faraday::FollowRedirects::Middleware
+      conn.adapter Faraday.default_adapter
+    end
+  end
+
+  def user_agent
+    ENV.fetch('USER_AGENT', 'repos.ecosyste.ms')
+  end
+end

--- a/env.example
+++ b/env.example
@@ -8,3 +8,4 @@ POSTGRES_PORT=5432
 # COMMITS_DOMAIN= # default: https://commits.ecosyste.ms
 # PACKAGES_DOMAIN= # default: https://packages.ecosyste.ms
 # GITHUB_RATE_LIMIT_BUFFER= # default: 100
+# SHODAN_API_KEY= # optional: enables `rake hosts:discover`, needs a paid shodan plan for the search api

--- a/lib/tasks/hosts.rake
+++ b/lib/tasks/hosts.rake
@@ -38,6 +38,33 @@ namespace :hosts do
     end
   end
 
+  desc 'Find public gitea/forgejo/gitlab instances with shodan.io. CREATE=true adds them'
+  task discover: :environment do
+    CronLock.acquire("hosts:discover", ttl: 1.hour) do
+      create = ENV['CREATE'] == 'true'
+
+      result = ShodanHostDiscovery.new(
+        create: create,
+        queries: ENV['QUERY'].presence || ShodanHostDiscovery::QUERIES,
+        pages: ENV.fetch('PAGES', ShodanHostDiscovery::DEFAULT_PAGES),
+        limit: ENV.fetch('LIMIT', ShodanHostDiscovery::DEFAULT_LIMIT)
+      ).discover
+
+      result[:candidates].each do |candidate|
+        puts "[repos] #{candidate.kind} #{candidate.url}#{" #{candidate.version}" if candidate.version}"
+      end
+
+      if result[:candidates].any? && !create
+        puts "[repos] add to db/seeds.rb or re-run with CREATE=true:"
+        result[:candidates].each { |candidate| puts candidate.to_seed_line }
+      end
+
+      puts "[repos] shodan discovery found=#{result[:found]} probed=#{result[:probed]} candidates=#{result[:candidates].length} created=#{result[:created].length}"
+    end
+  rescue ShodanHostDiscovery::MissingApiKey, ShodanHostDiscovery::ApiError => e
+    abort "[repos] #{e.message}"
+  end
+
   desc 'Print the GitLab token stored in redis for HOST'
   task get_gitlab_token: :environment do
     host = Host.find_by_name!(ENV['HOST'].presence || 'GitLab')

--- a/test/services/shodan_host_discovery_test.rb
+++ b/test/services/shodan_host_discovery_test.rb
@@ -101,6 +101,40 @@ class ShodanHostDiscoveryTest < ActiveSupport::TestCase
     assert_not_requested :get, "https://private.example.com/api/v1/version"
   end
 
+  test "skips instances that disallow the api in robots.txt" do
+    stub_search([{ 'hostnames' => ['api-blocked.example.com'] }])
+    stub_request(:get, "https://api-blocked.example.com/robots.txt")
+      .to_return(status: 200, body: "User-agent: *\nDisallow: /api\n")
+
+    assert_empty discovery.discover[:candidates]
+    assert_not_requested :get, "https://api-blocked.example.com/api/v1/version"
+  end
+
+  test "skips domains that resolve inside our own network" do
+    stub_search([{ 'hostnames' => ['git.example.com'] }])
+    service = discovery
+    service.stubs(:resolved_addresses).with('git.example.com').returns([IPAddr.new('127.0.0.1')])
+
+    result = service.discover
+
+    assert_equal 1, result[:probed]
+    assert_empty result[:candidates]
+    assert_not_requested :get, "https://git.example.com/robots.txt"
+  end
+
+  test "does not follow redirects off the candidate" do
+    metadata = 'http://169.254.169.254/latest/meta-data/'
+    stub_search([{ 'hostnames' => ['redirect.example.com'] }])
+    stub_request(:get, "https://redirect.example.com/robots.txt").to_return(status: 404, body: '')
+    stub_request(:get, "https://redirect.example.com/api/v1/version")
+      .to_return(status: 302, headers: { 'Location' => metadata })
+    stub_request(:get, "https://redirect.example.com/api/v4/projects?per_page=1&simple=true")
+      .to_return(status: 302, headers: { 'Location' => metadata })
+
+    assert_empty discovery.discover[:candidates]
+    assert_not_requested :get, metadata
+  end
+
   test "skips hosts that are already known" do
     create(:host, name: 'Known', url: 'https://git.example.com', kind: 'gitea')
     stub_search([{ 'hostnames' => ['git.example.com'] }])
@@ -113,7 +147,7 @@ class ShodanHostDiscoveryTest < ActiveSupport::TestCase
   end
 
   test "ignores ip addresses and unroutable hostnames" do
-    stub_search([{ 'hostnames' => ['192.168.0.1', 'git.local', 'localhost', 'gitea'], 'http' => { 'host' => '10.0.0.1' } }])
+    stub_search([{ 'hostnames' => ['192.168.0.1', 'git.local', 'git.localhost', 'localhost', 'gitea'], 'http' => { 'host' => '10.0.0.1' } }])
 
     assert_equal 0, discovery.discover[:found]
   end

--- a/test/services/shodan_host_discovery_test.rb
+++ b/test/services/shodan_host_discovery_test.rb
@@ -1,0 +1,211 @@
+require "test_helper"
+
+class ShodanHostDiscoveryTest < ActiveSupport::TestCase
+  SEARCH_URL = "https://api.shodan.io/shodan/host/search"
+
+  setup do
+    @query = 'http.html:"Powered by Gitea"'
+  end
+
+  def stub_search(matches, query: @query, page: 1, status: 200, body: nil)
+    body ||= { 'matches' => matches, 'total' => matches.length }.to_json
+
+    stub_request(:get, SEARCH_URL)
+      .with(query: { 'key' => 'shodan-key', 'query' => query, 'page' => page.to_s })
+      .to_return(status: status, body: body, headers: { 'Content-Type' => 'application/json' })
+  end
+
+  def stub_gitea(domain, version: '1.22.0', forgejo: false, repositories: 1)
+    stub_request(:get, "https://#{domain}/robots.txt").to_return(status: 404, body: '')
+    stub_request(:get, "https://#{domain}/api/v1/version")
+      .to_return(status: 200, body: { version: version }.to_json)
+    stub_request(:get, "https://#{domain}/api/v1/repos/search?limit=1")
+      .to_return(status: 200, body: { ok: true, data: Array.new(repositories) { |i| { id: i } } }.to_json)
+
+    if forgejo
+      stub_request(:get, "https://#{domain}/api/forgejo/v1/version")
+        .to_return(status: 200, body: { version: '11.0.0' }.to_json)
+    else
+      stub_request(:get, "https://#{domain}/api/forgejo/v1/version").to_return(status: 404, body: '')
+    end
+  end
+
+  def stub_gitlab(domain, projects: [{ id: 1 }])
+    stub_request(:get, "https://#{domain}/robots.txt").to_return(status: 404, body: '')
+    stub_request(:get, "https://#{domain}/api/v1/version").to_return(status: 404, body: '')
+    stub_request(:get, "https://#{domain}/api/v4/projects?per_page=1&simple=true")
+      .to_return(status: 200, body: projects.to_json)
+  end
+
+  def discovery(**options)
+    ShodanHostDiscovery.new(**{ api_key: 'shodan-key', queries: [@query] }.merge(options))
+  end
+
+  test "raises when no api key is configured" do
+    assert_raises(ShodanHostDiscovery::MissingApiKey) do
+      discovery(api_key: nil).discover
+    end
+  end
+
+  test "finds a gitea instance" do
+    stub_search([{ 'hostnames' => ['git.example.com'] }])
+    stub_gitea('git.example.com')
+
+    result = discovery.discover
+
+    assert_equal 1, result[:found]
+    assert_equal 1, result[:probed]
+    candidate = result[:candidates].sole
+    assert_equal 'git.example.com', candidate.domain
+    assert_equal 'https://git.example.com', candidate.url
+    assert_equal 'gitea', candidate.kind
+    assert_equal '1.22.0', candidate.version
+    assert_empty result[:created]
+  end
+
+  test "identifies forgejo by its own version api" do
+    stub_search([{ 'hostnames' => ['forge.example.com'] }])
+    stub_gitea('forge.example.com', forgejo: true)
+
+    assert_equal 'forgejo', discovery.discover[:candidates].sole.kind
+  end
+
+  test "finds a gitlab instance by listing projects anonymously" do
+    stub_search([{ 'hostnames' => ['gitlab.example.com'] }])
+    stub_gitlab('gitlab.example.com')
+
+    candidate = discovery.discover[:candidates].sole
+    assert_equal 'gitlab', candidate.kind
+    assert_nil candidate.version
+  end
+
+  test "skips instances with no public repositories" do
+    stub_search([{ 'hostnames' => ['empty.example.com'], 'http' => { 'host' => 'gitlab.example.com' } }])
+    stub_gitea('empty.example.com', repositories: 0)
+    stub_request(:get, "https://empty.example.com/api/v4/projects?per_page=1&simple=true")
+      .to_return(status: 404, body: '')
+    stub_gitlab('gitlab.example.com', projects: [])
+
+    result = discovery.discover
+
+    assert_equal 2, result[:probed]
+    assert_empty result[:candidates]
+  end
+
+  test "skips instances that disallow crawling in robots.txt" do
+    stub_search([{ 'hostnames' => ['private.example.com'] }])
+    stub_request(:get, "https://private.example.com/robots.txt")
+      .to_return(status: 200, body: "User-agent: *\nDisallow: /\n")
+
+    assert_empty discovery.discover[:candidates]
+    assert_not_requested :get, "https://private.example.com/api/v1/version"
+  end
+
+  test "skips hosts that are already known" do
+    create(:host, name: 'Known', url: 'https://git.example.com', kind: 'gitea')
+    stub_search([{ 'hostnames' => ['git.example.com'] }])
+
+    result = discovery.discover
+
+    assert_equal 1, result[:found]
+    assert_equal 0, result[:probed]
+    assert_empty result[:candidates]
+  end
+
+  test "ignores ip addresses and unroutable hostnames" do
+    stub_search([{ 'hostnames' => ['192.168.0.1', 'git.local', 'localhost', 'gitea'], 'http' => { 'host' => '10.0.0.1' } }])
+
+    assert_equal 0, discovery.discover[:found]
+  end
+
+  test "deduplicates domains across matches and queries" do
+    other_query = 'http.title:"GitLab"'
+    stub_search([{ 'hostnames' => ['git.example.com'], 'http' => { 'host' => 'git.example.com' } }])
+    stub_search([{ 'hostnames' => ['git.example.com'] }], query: other_query)
+    stub_gitea('git.example.com')
+
+    result = discovery(queries: [@query, other_query]).discover
+
+    assert_equal 1, result[:found]
+    assert_equal 1, result[:candidates].length
+  end
+
+  test "stops paging when a page is not full" do
+    stub_search([{ 'hostnames' => ['git.example.com'] }])
+    stub_gitea('git.example.com')
+
+    discovery(pages: 3).discover
+
+    assert_not_requested :get, SEARCH_URL, query: hash_including({ 'page' => '2' })
+  end
+
+  test "creates hosts when asked to" do
+    stub_search([{ 'hostnames' => ['git.example.com'] }])
+    stub_gitea('git.example.com')
+
+    result = discovery(create: true).discover
+
+    host = result[:created].sole
+    assert_equal 'git.example.com', host.name
+    assert_equal 'https://git.example.com', host.url
+    assert_equal 'gitea', host.kind
+    assert_equal '1.22.0', host.version
+    assert_equal 1, Host.where(url: 'https://git.example.com').count
+  end
+
+  test "reports rather than raises when a host cannot be saved" do
+    create(:host, name: 'git.example.com', url: 'https://other.example.com', kind: 'gitea')
+    stub_search([{ 'hostnames' => ['git.example.com'] }])
+    stub_gitea('git.example.com')
+    output = StringIO.new
+
+    result = discovery(create: true, output: output).discover
+
+    assert_equal 1, result[:candidates].length
+    assert_empty result[:created]
+    assert_includes output.string, 'skipping git.example.com'
+  end
+
+  test "raises without leaking the api key when shodan rejects the request" do
+    stub_search([], status: 401, body: { error: 'Invalid API key' }.to_json)
+
+    error = assert_raises(ShodanHostDiscovery::ApiError) { discovery.discover }
+
+    assert_includes error.message, 'HTTP 401'
+    assert_includes error.message, 'Invalid API key'
+    assert_not_includes error.message, 'shodan-key'
+  end
+
+  test "raises when shodan returns an unreadable body" do
+    stub_search([], body: '<html>nope</html>')
+
+    assert_raises(ShodanHostDiscovery::ApiError) { discovery.discover }
+  end
+
+  test "raises when shodan cannot be reached" do
+    stub_request(:get, SEARCH_URL).with(query: hash_including({})).to_timeout
+
+    assert_raises(ShodanHostDiscovery::ApiError) { discovery.discover }
+  end
+
+  test "skips a candidate that stops responding mid-probe" do
+    stub_search([{ 'hostnames' => ['git.example.com'] }])
+    stub_request(:get, "https://git.example.com/robots.txt").to_return(status: 404, body: '')
+    stub_request(:get, "https://git.example.com/api/v1/version").to_timeout
+    stub_request(:get, "https://git.example.com/api/v4/projects?per_page=1&simple=true").to_timeout
+
+    assert_empty discovery.discover[:candidates]
+  end
+
+  test "limits how many unknown domains are probed" do
+    stub_search([{ 'hostnames' => ['a.example.com', 'b.example.com'] }])
+    stub_gitea('a.example.com')
+
+    result = discovery(limit: 1).discover
+
+    assert_equal 2, result[:found]
+    assert_equal 1, result[:probed]
+    assert_equal 1, result[:candidates].length
+    assert_not_requested :get, "https://b.example.com/robots.txt"
+  end
+end

--- a/test/tasks/hosts_rake_test.rb
+++ b/test/tasks/hosts_rake_test.rb
@@ -11,6 +11,10 @@ class HostsRakeTest < ActiveSupport::TestCase
     ENV.delete('URL')
     ENV.delete('DAYS')
     ENV.delete('HOST')
+    ENV.delete('SHODAN_API_KEY')
+    ENV.delete('QUERY')
+    ENV.delete('CREATE')
+    REDIS.del('cron_lock:hosts:discover')
   end
 
   test "get_gitlab_token prints the token from redis" do
@@ -136,6 +140,55 @@ class HostsRakeTest < ActiveSupport::TestCase
 
     assert_raises(SystemExit) do
       capture_io { Rake::Task["hosts:rotate_gitlab_token"].execute }
+    end
+  end
+
+  def stub_shodan_gitea_instance
+    stub_request(:get, "https://api.shodan.io/shodan/host/search")
+      .with(query: { 'key' => 'shodan-key', 'query' => 'test-query', 'page' => '1' })
+      .to_return(status: 200, body: { matches: [{ hostnames: ['git.example.com'] }] }.to_json)
+    stub_request(:get, "https://git.example.com/robots.txt").to_return(status: 404, body: '')
+    stub_request(:get, "https://git.example.com/api/v1/version")
+      .to_return(status: 200, body: { version: '1.22.0' }.to_json)
+    stub_request(:get, "https://git.example.com/api/forgejo/v1/version").to_return(status: 404, body: '')
+    stub_request(:get, "https://git.example.com/api/v1/repos/search?limit=1")
+      .to_return(status: 200, body: { ok: true, data: [{ id: 1 }] }.to_json)
+  end
+
+  test "discover reports candidates without creating them" do
+    ENV['SHODAN_API_KEY'] = 'shodan-key'
+    ENV['QUERY'] = 'test-query'
+    stub_shodan_gitea_instance
+
+    out, _ = capture_io { Rake::Task["hosts:discover"].execute }
+
+    assert_match '[repos] gitea https://git.example.com 1.22.0', out
+    assert_match '{name: "git.example.com", url: "https://git.example.com", kind: "gitea"},', out
+    assert_match 'found=1 probed=1 candidates=1 created=0', out
+    assert_equal 0, Host.count
+  end
+
+  test "discover creates hosts when CREATE is set" do
+    ENV['SHODAN_API_KEY'] = 'shodan-key'
+    ENV['QUERY'] = 'test-query'
+    ENV['CREATE'] = 'true'
+    stub_shodan_gitea_instance
+
+    out, _ = capture_io { Rake::Task["hosts:discover"].execute }
+
+    assert_match 'candidates=1 created=1', out
+    host = Host.sole
+    assert_equal 'git.example.com', host.name
+    assert_equal 'https://git.example.com', host.url
+    assert_equal 'gitea', host.kind
+  end
+
+  test "discover aborts without an api key" do
+    ENV.delete('SHODAN_API_KEY')
+    ENV['QUERY'] = 'test-query'
+
+    assert_raises(SystemExit) do
+      capture_io { Rake::Task["hosts:discover"].execute }
     end
   end
 end


### PR DESCRIPTION
Closes #1049

Hosts are currently added by hand, one PR per instance (see #1139), so there is no way to find new public forges other than someone stumbling across one. This adds a rake task that searches shodan.io for candidates, verifies each one against the instance itself then reports the ones worth indexing.

## How it works

Shodan only supplies candidate domains. The forge kind is decided by probing the instance, never by the search query, because gitea and forgejo instances are not reliably distinguishable from their HTML.

Each candidate goes through the following checks, in order and is dropped at the first failure:

1. **Shape.** IP addresses, single label names, wildcards and reserved suffixes (`.local`, `.localhost`, `.internal`, `.test` and friends) are discarded, reusing `Host.normalize_domain`.
2. **Already known.** Anything `Host.find_by_domain` recognises is skipped, so repeat runs only surface new instances.
3. **Address.** The domain is resolved and dropped if it points anywhere inside our own network: loopback, private, link-local, `0.0.0.0/8`, `100.64.0.0/10` or `::/128`. A name that does not resolve is left alone, since the request itself fails a moment later anyway.
4. **robots.txt.** Fetched and evaluated with `Host#can_crawl_api?`, so `Disallow: /api` blocks a probe just like a blanket `Disallow: /` does. Nothing is requested from the instance's API until this passes.
5. **Kind.** `/api/v1/version` identifies gitea or forgejo, with `/api/forgejo/v1/version` telling the two apart. `/api/v4/projects?per_page=1&simple=true` identifies gitlab.
6. **Public repositories.** `/api/v1/repos/search` for gitea or forgejo and the projects call above for gitlab, must return at least one repository. An instance that requires an account, or that has nothing published, is not worth indexing.

Gitlab does not report its version to an anonymous caller, so version is left blank for gitlab hosts and only gitea or forgejo candidates carry one.

## Usage

Dry run by default, printing paste ready `db/seeds.rb` lines:

$ rake hosts:discover
[repos] gitea https://git.example.com 1.22.0
[repos] add to db/seeds.rb or re-run with CREATE=true:
  {name: "git.example.com", url: "https://git.example.com", kind: "gitea"},
[repos] shodan discovery found=214 probed=37 candidates=1 created=0

`CREATE=true` creates the `Host` records instead. `QUERY`, `PAGES` and `LIMIT` tune the search, where `LIMIT` caps how many unknown domains get probed so outbound requests stay bounded per run. The task runs under `CronLock` like its neighbours and aborts with exit 1 if the key is missing or rejected.

## Notes

- Needs `SHODAN_API_KEY`, documented in `env.example`. The search API requires a paid shodan plan, so the task is a no op without one.
- No entry was added to the `app.json` cron list. Creating hosts unreviewed felt like a maintainer decision rather than something to bake in, plus a scheduled task would abort nightly for anyone without a key. Happy to add a schedule if you want it running automatically.
- Redirects are not followed. Every request here is driven by a hostname shodan supplied, so a `Location` header would be an easy way to move us onto an address that was never checked. That plus the address check above keeps a hostile candidate from steering the task at a private endpoint.
- Shodan API failures raise with the HTTP status and shodan's own error message. The API key is never included in an error or log line.

## Testing

20 tests for the service plus 3 for the rake task, all stubbed with webmock, following the existing `robots_txt_parser_test` and `takedown_rake_test` conventions. They cover gitea, forgejo and gitlab detection, a blanket robots.txt refusal, a robots.txt that blocks only `/api`, a domain resolving to a loopback address, a redirect off the candidate that is not followed, known hosts, empty instances, IP and unroutable filtering, dedupe across queries, page termination, `CREATE=true`, an unsaveable host, a 401 from shodan, an unreadable body, an unreachable shodan and a candidate that times out mid probe.

Full suite passes locally: `507 runs, 1249 assertions, 0 failures, 0 errors, 22 skips`.