### PR TITLE
Add partial index for repository language queries

### DIFF
--- a/db/migrate/20260904123825_add_host_language_index_to_repositories.rb
+++ b/db/migrate/20260904123825_add_host_language_index_to_repositories.rb
@@ -1,0 +1,11 @@
+class AddHostLanguageIndexToRepositories < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :repositories,
+              [:host_id, :language],
+              where: "fork = false",
+              algorithm: :concurrently,
+              name: "index_repositories_on_host_language_nonfork"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_05_110000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_04_123825) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -206,6 +206,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_05_110000) do
     t.datetime "usage_updated_at"
     t.string "uuid"
     t.index "host_id, lower((full_name)::text)", name: "index_repositories_on_host_id_lower_full_name", unique: true
+    t.index ["host_id", "language"], name: "index_repositories_on_host_language_nonfork", where: "(fork = false)"
     t.index ["host_id", "uuid"], name: "index_repositories_on_host_id_uuid", unique: true
     t.index ["owner"], name: "index_repositories_on_owner"
   end


### PR DESCRIPTION
Fixes #1192

## Summary

- Add a composite index on `repositories(host_id, language)`.
- Limit the index to non-fork repositories with `WHERE fork = false`.
- Create the index concurrently to avoid blocking writes on the repositories table.
- Update the generated database schema.

## Motivation

Filtering a host's non-fork repositories by language currently requires a sequential scan of the repositories table and can exceed the PostgreSQL statement timeout.

The new partial index matches this query pattern while excluding forked repositories from the index.

## Verification

- Confirmed the migration applies successfully.
- Confirmed the migration rolls back successfully.
- Verified PostgreSQL uses an `Index Only Scan` for the affected query.
- Ran the complete test suite:
  - 484 runs
  - 1,175 assertions
  - 0 failures
  - 0 errors
- Passed Ruby syntax, Rails autoloading and whitespace checks.

