### PR TITLE
Reconcile hosts.repositories_count daily and humanise homepage stats

### DIFF
--- a/app.json
+++ b/app.json
@@ -45,6 +45,10 @@
       "schedule": "0 2 * * *"
     },
     {
+      "command": "bundle exec rake hosts:update_repositories_counts",
+      "schedule": "0 5 * * *"
+    },
+    {
       "command": "bundle exec rake sitemap:refresh_with_lock",
       "schedule": "0 6 * * *"
     },

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -8,6 +8,39 @@ class Host < ApplicationRecord
 
   scope :kind, ->(kind) { where(kind: kind) }
 
+  ESTIMATE_THRESHOLD = 1_000_000
+
+  def self.repositories_count_estimates
+    reltuples = connection.select_value("SELECT reltuples::bigint FROM pg_class WHERE oid = 'repositories'::regclass").to_i
+    row = connection.select_one("SELECT most_common_vals::text AS v, array_to_string(most_common_freqs, ',') AS f FROM pg_stats WHERE tablename = 'repositories' AND attname = 'host_id'")
+    return {} if row.nil? || row['v'].blank?
+    ids = row['v'].delete('{}').split(',').map(&:to_i)
+    freqs = row['f'].split(',').map(&:to_f)
+    ids.zip(freqs).to_h.transform_values { |f| (reltuples * f).round }
+  end
+
+  def self.update_repositories_counts
+    estimates = repositories_count_estimates
+    find_each do |host|
+      host.update_column(:repositories_count, host.compute_repositories_count(estimates))
+    rescue ActiveRecord::QueryCanceled => e
+      Rails.logger.warn "repositories_count timeout for host #{host.id} (#{host.name}), keeping #{host.repositories_count}: #{e.message}"
+    end
+  end
+
+  def update_repositories_count
+    update_column(:repositories_count, compute_repositories_count)
+  end
+
+  def compute_repositories_count(estimates = nil)
+    estimates ||= self.class.repositories_count_estimates
+    if repositories_count.to_i >= ESTIMATE_THRESHOLD && estimates[id]
+      estimates[id]
+    else
+      repositories.count
+    end
+  end
+
   def self.find_by_name(name)
     return nil if name.blank?
     host = Host.find_by('lower(name) = ?', name.downcase)

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -11,7 +11,7 @@
     <div class="col-md-2 col-6 mb-3">
       <div class="card text-center">
         <div class="card-body">
-          <h4 class="card-title text-success mb-1"><%= number_with_delimiter @hosts.sum(&:repositories_count) %></h4>
+          <h4 class="card-title text-success mb-1"><%= number_to_human @hosts.sum(&:repositories_count) %></h4>
           <p class="card-text small text-muted mb-0"><%= Repository.model_name.human(count: 2) %></p>
         </div>
       </div>
@@ -19,7 +19,7 @@
     <div class="col-md-2 col-6 mb-3">
       <div class="card text-center">
         <div class="card-body">
-          <h4 class="card-title text-warning mb-1"><%= number_with_delimiter @hosts.sum(&:owners_count) %></h4>
+          <h4 class="card-title text-warning mb-1"><%= number_to_human @hosts.sum(&:owners_count) %></h4>
           <p class="card-text small text-muted mb-0"><%= Owner.model_name.human(count: 2) %></p>
         </div>
       </div>
@@ -27,7 +27,7 @@
     <div class="col-md-2 col-6 mb-3">
       <div class="card text-center">
         <div class="card-body">
-          <h4 class="card-title text-info mb-1"><%= number_with_delimiter Tag.fast_total %></h4>
+          <h4 class="card-title text-info mb-1"><%= number_to_human Tag.fast_total %></h4>
           <p class="card-text small text-muted mb-0"><%= Tag.model_name.human(count: 2) %></p>
         </div>
       </div>
@@ -35,7 +35,7 @@
     <div class="col-md-2 col-6 mb-3">
       <div class="card text-center">
         <div class="card-body">
-          <h4 class="card-title text-secondary mb-1"><%= number_with_delimiter Manifest.fast_total %></h4>
+          <h4 class="card-title text-secondary mb-1"><%= number_to_human Manifest.fast_total %></h4>
           <p class="card-text small text-muted mb-0"><%= Manifest.model_name.human(count: 2) %></p>
         </div>
       </div>
@@ -43,7 +43,7 @@
     <div class="col-md-2 col-6 mb-3">
       <div class="card text-center">
         <div class="card-body">
-          <h4 class="card-title text-dark mb-1"><%= number_with_delimiter Dependency.fast_total %></h4>
+          <h4 class="card-title text-dark mb-1"><%= number_to_human Dependency.fast_total %></h4>
           <p class="card-text small text-muted mb-0"><%= Dependency.model_name.human(count: 2) %></p>
         </div>
       </div>
@@ -57,7 +57,7 @@
         <%= link_to t(kind), kind_hosts_path(kind), class: 'text-decoration-none' %>
         <span class="text-black-50">
           <%= number_with_delimiter(hosts.length) %> <%= t('virtual.models.instance', count: hosts.length) %> -
-          <%= number_with_delimiter(hosts.sum(&:repositories_count)) %> <%= Repository.model_name.human(count: hosts.sum(&:repositories_count)) %>
+          <%= number_to_human(hosts.sum(&:repositories_count)) %> <%= Repository.model_name.human(count: hosts.sum(&:repositories_count)) %>
         </span>
       </div>
        <ul class="list-group list-group-flush">
@@ -65,7 +65,7 @@
           <li class="list-group-item">
             <%= link_to host.name.downcase, host %>
             <span class="text-black-50">
-              <%= number_with_delimiter(host.repositories_count) %> <%= Repository.model_name.human(count: host.repositories_count) %>
+              <%= number_to_human(host.repositories_count) %> <%= Repository.model_name.human(count: host.repositories_count) %>
             </span>
           </li>
         <% end %>

--- a/lib/tasks/hosts.rake
+++ b/lib/tasks/hosts.rake
@@ -1,6 +1,13 @@
 require_relative '../cron_lock'
 
 namespace :hosts do
+  desc 'update repositories_count for all hosts'
+  task update_repositories_counts: :environment do
+    CronLock.acquire("hosts:update_repositories_counts", ttl: 23.hours) do
+      Host.update_repositories_counts
+    end
+  end
+
   desc 'check github tokens'
   task check_github_tokens: :environment do
     CronLock.acquire("hosts:check_github_tokens", ttl: 23.hours) do

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -73,6 +73,62 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  context 'update_repositories_counts' do
+    setup do
+      @host1 = create(:host)
+      @host2 = create(:host)
+      create_list(:repository, 3, host: @host1)
+      create_list(:repository, 5, host: @host2)
+    end
+
+    should 'return empty hash from repositories_count_estimates when pg_stats has no data' do
+      Host.connection.stubs(:select_one).returns(nil)
+      assert_equal({}, Host.repositories_count_estimates)
+    end
+
+    should 'parse pg_stats into id => estimate hash' do
+      Host.connection.stubs(:select_value).returns(1000)
+      Host.connection.stubs(:select_one).returns({ 'v' => '{1,2,3}', 'f' => '0.5,0.3,0.2' })
+      assert_equal({ 1 => 500, 2 => 300, 3 => 200 }, Host.repositories_count_estimates)
+    end
+
+    should 'use real count when current repositories_count is below threshold' do
+      Host.stubs(:repositories_count_estimates).returns({ @host1.id => 999 })
+      Host.update_repositories_counts
+      assert_equal 3, @host1.reload.repositories_count
+      assert_equal 5, @host2.reload.repositories_count
+    end
+
+    should 'use pg_stats estimate when current repositories_count is at or above threshold' do
+      @host1.update_column(:repositories_count, Host::ESTIMATE_THRESHOLD)
+      Host.stubs(:repositories_count_estimates).returns({ @host1.id => 5_000_000 })
+      Host.update_repositories_counts
+      assert_equal 5_000_000, @host1.reload.repositories_count
+      assert_equal 5, @host2.reload.repositories_count
+    end
+
+    should 'fall back to real count when above threshold but no estimate available' do
+      @host1.update_column(:repositories_count, Host::ESTIMATE_THRESHOLD)
+      Host.stubs(:repositories_count_estimates).returns({})
+      assert_equal 3, @host1.compute_repositories_count
+    end
+
+    should 'keep existing value and continue when a count times out' do
+      @host1.update_column(:repositories_count, 111)
+      Host.stubs(:repositories_count_estimates).returns({})
+      Host.any_instance.stubs(:compute_repositories_count).raises(ActiveRecord::QueryCanceled.new('timeout')).then.returns(5)
+      assert_nothing_raised { Host.update_repositories_counts }
+      assert_equal 111, @host1.reload.repositories_count
+      assert_equal 5, @host2.reload.repositories_count
+    end
+
+    should 'update a single host via instance method' do
+      Host.stubs(:repositories_count_estimates).returns({})
+      @host1.update_repositories_count
+      assert_equal 3, @host1.reload.repositories_count
+    end
+  end
+
   context 'associations' do
     should have_many(:repositories)
     should have_many(:owners)


### PR DESCRIPTION
`hosts.repositories_count` has been unmaintained since `counter_culture :host` was removed from `Repository` in Nov 2025 (2af4929). GitHub's counter was ~55M behind the actual row count.

Adds `Host.update_repositories_counts` and a daily cron. Hosts whose current `repositories_count` is ≥ 1M take a `pg_stats` estimate (`reltuples × most_common_freqs`), since a real `COUNT(*)` on GitHub's ~340M rows won't complete under `statement_timeout`; everything else does a real count via the existing `(host_id, uuid)` index. A per-host timeout is caught so one slow count doesn't abort the run.

Homepage stat cards and per-host repo counts switch to `number_to_human` since the large values are now explicitly estimates. The hosts count stays exact.